### PR TITLE
Send "merchant_reference" for each refund call.

### DIFF
--- a/src/Endpoints/Payments.php
+++ b/src/Endpoints/Payments.php
@@ -204,10 +204,12 @@ class Payments extends Base
     public function refund($id, $totalRefund = true, $amount = null, $merchantReference = "")
     {
         $req = $this->request(self::PAYMENTS_PATH . "/$id/refund");
+        $requestBody = ["merchant_reference" => $merchantReference];
 
         if (!$totalRefund) {
-            $req->setRequestBody(array("amount" => $amount, "merchant_reference" => $merchantReference));
+            $requestBody['amount'] = $amount;
         }
+        $req->setRequestBody($requestBody);
 
         $res = $req->post();
         if ($res->isError()) {

--- a/src/Endpoints/Payments.php
+++ b/src/Endpoints/Payments.php
@@ -207,7 +207,7 @@ class Payments extends Base
         $requestBody = ["merchant_reference" => $merchantReference];
 
         if (!$totalRefund) {
-            $requestBody['amount'] = $amount;
+            $requestBody["amount"] = $amount;
         }
         $req->setRequestBody($requestBody);
 


### PR DESCRIPTION
Currently "merchant_reference" is only taken into account when calling for a partial refund.
Proposed change : send "merchant_reference" as a body parameter for each /refund call.