### PR TITLE
Fix merchant reference only on partial refunds

### DIFF
--- a/src/Endpoints/Payments.php
+++ b/src/Endpoints/Payments.php
@@ -205,9 +205,12 @@ class Payments extends Base
     {
         $req = $this->request(self::PAYMENTS_PATH . "/$id/refund");
 
+        $body = array("merchant_reference" => $merchantReference);
         if (!$totalRefund) {
-            $req->setRequestBody(array("amount" => $amount, "merchant_reference" => $merchantReference));
+            $body["amount"] = $amount;
         }
+
+        $req->setRequestBody($body);
 
         $res = $req->post();
         if ($res->isError()) {


### PR DESCRIPTION
The merchant reference for refunds has been added too quickly and we missed the obvious: as it was, it would only be passed to Alma for partial refunds and not for full refunds.

This PR fixes that.