### PR TITLE
Remove ps4 warnings

### DIFF
--- a/tests/Integration/Endpoints/PaymentTest.php
+++ b/tests/Integration/Endpoints/PaymentTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Alma\API\Tests\Integration;
+namespace Alma\API\Tests\Integration\Endpoints;
 
 use Alma\API\Client;
 use Alma\API\Entities\Instalment;
@@ -8,8 +8,7 @@ use Alma\API\Entities\Payment;
 use PHPUnit\Framework\TestCase;
 
 final class PaymentsTest extends TestCase
-{
-    protected static $almaClient;
+{    protected static $almaClient;
 
     public static function setUpBeforeClass()
     {

--- a/tests/Integration/Endpoints/PaymentsTest.php
+++ b/tests/Integration/Endpoints/PaymentsTest.php
@@ -8,7 +8,8 @@ use Alma\API\Entities\Payment;
 use PHPUnit\Framework\TestCase;
 
 final class PaymentsTest extends TestCase
-{    protected static $almaClient;
+{
+    protected static $almaClient;
 
     public static function setUpBeforeClass()
     {

--- a/tests/Unit/ArrayUtilsTest.php
+++ b/tests/Unit/ArrayUtilsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Alma\API\Tests;
+namespace Alma\API\Tests\Unit;
 
 use Alma\API\Lib\ArrayUtils;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/ClientContextTest.php
+++ b/tests/Unit/ClientContextTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Alma\API\Tests;
+namespace Alma\API\Tests\Unit;
 
 use Alma\API\ClientContext;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/ClientOptionsValidatorTest.php
+++ b/tests/Unit/ClientOptionsValidatorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Alma\API\Tests;
+namespace Alma\API\Tests\Unit;
 
 use Alma\API\Lib\ClientOptionsValidator;
 use Alma\API\Client;

--- a/tests/Unit/Endpoints/PaymentsTest.php
+++ b/tests/Unit/Endpoints/PaymentsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Alma\API\Tests\Unit;
+namespace Alma\API\Tests\Unit\Endpoints;
 
 use Mockery;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/RequestErrorTest.php
+++ b/tests/Unit/RequestErrorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Alma\API\Tests;
+namespace Alma\API\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Alma\API\Response;


### PR DESCRIPTION
As seen in #30, classes in the tests namespace doesn't follow PSR4 rules. When running `composer install` after requiring this lib, there are a bunch of warnings during the autoload generation : 

```
Class Alma\API\Tests\ClientOptionsValidatorTest located in ./vendor/alma/alma-php-client/tests/unit/ClientOptionsValidatorTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Alma\API\Tests\Unit\PaymentsTest located in ./vendor/alma/alma-php-client/tests/unit/Endpoints/PaymentsTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Alma\API\Tests\ClientContextTest located in ./vendor/alma/alma-php-client/tests/unit/ClientContextTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Alma\API\Tests\ArrayUtilsTest located in ./vendor/alma/alma-php-client/tests/unit/ArrayUtilsTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Alma\API\Tests\RequestErrorTest located in ./vendor/alma/alma-php-client/tests/unit/RequestErrorTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Alma\API\Tests\Integration\PaymentsTest located in ./vendor/alma/alma-php-client/tests/integration/Endpoints/PaymentTest.php does not comply with psr-4 autoloading standard. Skipping.
```
