### PR TITLE
feat: allow api url override with env variable

### DIFF
--- a/src/Lib/ClientOptionsValidator.php
+++ b/src/Lib/ClientOptionsValidator.php
@@ -57,8 +57,8 @@ class ClientOptionsValidator
     {
         $config = [
             'api_root' => [
-                Client::TEST_MODE => Client::SANDBOX_API_URL,
-                Client::LIVE_MODE => Client::LIVE_API_URL
+                Client::TEST_MODE => $_ENV['ALMA_SANDBOX_API_URL'] ?: Client::SANDBOX_API_URL,
+                Client::LIVE_MODE => $_ENV['ALMA_LIVE_API_URL'] ?: Client::LIVE_API_URL
             ],
             'force_tls' => 2,
             'mode' => Client::LIVE_MODE,


### PR DESCRIPTION
Use cases:
* testing live env on our integration with sandbox or staging URLs
* testing an API temporary environment (Docker / Kubernetes) instead of Sandbox / staging

TODO: allow this environment variables to be added in our integration platform repository
