### PR TITLE
feat: allow overriding root url with env variable

### DIFF
--- a/src/Lib/ClientOptionsValidator.php
+++ b/src/Lib/ClientOptionsValidator.php
@@ -57,8 +57,8 @@ class ClientOptionsValidator
     {
         $config = [
             'api_root' => [
-                Client::TEST_MODE => Client::SANDBOX_API_URL,
-                Client::LIVE_MODE => Client::LIVE_API_URL
+                Client::TEST_MODE => isset($_ENV['ALMA_TEST_API_ROOT']) ? $_ENV['ALMA_TEST_API_ROOT'] : Client::SANDBOX_API_URL,
+                Client::LIVE_MODE => isset($_ENV['ALMA_LIVE_API_ROOT']) ? $_ENV['ALMA_LIVE_API_ROOT'] : Client::LIVE_API_URL
             ],
             'force_tls' => 2,
             'mode' => Client::LIVE_MODE,


### PR DESCRIPTION
Overrides default api_root url with following env variables:
* ALMA_TEST_API_ROOT
* ALMA_LIVE_API_ROOT

This feat will allow to give a dynamic api_root url in E2E context or will allow to emulate live context on a test Alma service.