### PR TITLE
Move test files out the production autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,11 @@
   ],
   "autoload": {
     "psr-4": {
-      "Alma\\API\\": "src/",
+      "Alma\\API\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
       "Alma\\API\\Tests\\": "tests/"
     }
   },


### PR DESCRIPTION
### Reason for change

The application I work on uses this library and I noticed that Composer's autoloader referenced test files in production. 

### Code changes

In **composer.json** I moved `tests/` to [`autoload-dev`](https://getcomposer.org/doc/04-schema.md#autoload-dev).

### How to test

After installing the library without the dev dependencies (`composer up --no-dev`) you can check `tests/` has been removed from autoloader:
```diff
grep tests vendor/composer/autoload_static.php 
-            0 => __DIR__ . '/../..' . '/tests',
```

### Checklist for authors and reviewers

- [x] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [x] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [x] You understand the impact of this PR on existing code/features

### Non applicable

- [x] The PR implements the changes asked in the referenced task / issue
- [x] The tests are relevant, and cover the corner/error cases, not only the happy path
- [x] The changes include adequate logging and Datadog traces
- [x] Documentation is updated (API, developer documentation, ADR, Notion...)