### PR TITLE
fix: comptatibility PHP 8.2

### DIFF
--- a/src/Entities/Base.php
+++ b/src/Entities/Base.php
@@ -25,7 +25,7 @@
 
 namespace Alma\API\Entities;
 
-class Base
+class Base extends \stdClass
 {
     /** @var string */
     public $id;

--- a/src/PaginatedResults.php
+++ b/src/PaginatedResults.php
@@ -24,7 +24,6 @@
 
 namespace Alma\API;
 
-use Alma\API\Entities\Base;
 use Iterator;
 
 class PaginatedResults implements Iterator


### PR DESCRIPTION
### Reason for change

Deprecated Functionality: Creation of dynamic property

[ClickUp task](https://linear.app/almapay/issue/MPP-299/php-client-compatibility-with-php-82)

### Solutions

https://php.watch/versions/8.2/dynamic-properties-deprecated#stdClass