### PR TITLE
Run tests with all PHP versions supported

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -9,6 +9,19 @@ on:
 
 jobs:
   ci:
+    strategy:
+      matrix:
+        php-version:
+          - "5.6"
+          - "7.0"
+          - "7.1"
+          - "7.2"
+          - "7.3"
+          - "7.4"
+          - "8.0"
+          - "8.1"
+          - "8.2"
+
     runs-on: ubuntu-20.04
     defaults:
       run:
@@ -20,8 +33,8 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 5.6
-          tools: composer:v1
+          php-version: "${{ matrix.php-version }}"
+          tools: composer:v2
 
       - name: Validate composer.json and composer.lock
         run: composer validate
@@ -33,4 +46,4 @@ jobs:
         run: ./vendor/bin/phpcs src
 
       - name: Ensure unit test are green
-        run: ./vendor/bin/phpunit -c phpunit.ci.xml
+        run: ./vendor/bin/simple-phpunit -c phpunit.ci.xml

--- a/Makefile
+++ b/Makefile
@@ -20,13 +20,13 @@ composer:
 	docker exec -it -u www-data:www-data test-php /usr/bin/composer install
 
 test: up composer ## Execute PHPUnit tests
-	docker exec -it -u www-data test-php sh -c './vendor/bin/phpunit --testsuite "Alma PHP Client Unit Test Suite"'
+	docker exec -it -u www-data test-php sh -c './vendor/bin/simple-phpunit --testsuite "Alma PHP Client Unit Test Suite"'
 
 integration-test: up composer ## Execute intregration tests
-	docker exec -it -u www-data test-php sh -c './vendor/bin/phpunit --testsuite "Alma PHP Client Integration Test Suite"'
+	docker exec -it -u www-data test-php sh -c './vendor/bin/simple-phpunit --testsuite "Alma PHP Client Integration Test Suite"'
 
 test-all: up composer ## Execute All PHPUnit tests
-	docker exec -it -u www-data test-php sh -c './vendor/bin/phpunit'
+	docker exec -it -u www-data test-php sh -c './vendor/bin/simple-phpunit'
 
 connect: up ## Connect to test container
 	docker exec -it -u www-data:www-data test-php /bin/bash

--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
     "phpcompatibility/php-compatibility": "^9.0",
-    "phpunit/phpunit": "*",
     "roave/security-advisories": "@dev",
     "squizlabs/php_codesniffer": "^3.3",
+    "symfony/phpunit-bridge": "^5.2 || ^6.0",
     "mockery/mockery": "^1.3"
   },
   "license": "MIT",

--- a/phpunit.ci.xml
+++ b/phpunit.ci.xml
@@ -12,8 +12,12 @@
 
     <testsuites>
         <testsuite name="Alma PHP Client Unit Test Suite">
-            <directory>tests/unit</directory>
+            <directory>tests/Unit</directory>
         </testsuite>
     </testsuites>
+
+    <php>
+        <env name="SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT" value="1" />
+    </php>
 
 </phpunit>

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -12,17 +12,18 @@
 
     <testsuites>
         <testsuite name="Alma PHP Client Unit Test Suite">
-            <directory>tests/unit</directory>
+            <directory>tests/Unit</directory>
         </testsuite>
     </testsuites>
     <testsuites>
         <testsuite name="Alma PHP Client Integration Test Suite">
-            <directory>tests/integration</directory>
+            <directory>tests/Integration</directory>
         </testsuite>
     </testsuites>
     <php>
         <env name="ALMA_API_KEY" value="sk_test_xxxxxxxxxxxxxxxxxxxxxxxx"/>
         <env name="ALMA_API_ROOT" value="https://alma.api.url.eu"/>
+        <env name="SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT" value="1" />
     </php>
 
 </phpunit>

--- a/tests/Unit/RequestErrorTest.php
+++ b/tests/Unit/RequestErrorTest.php
@@ -52,7 +52,7 @@ class RequestErrorTest extends TestCase
      */
     public function testGetErrorMessage($req, $res, $expected)
     {
-        $requestError = new RequestError($res->errorMessage, $req, $res);
+        $requestError = new RequestError((string) $res->errorMessage, $req, $res);
 
         $this->assertEquals($expected, $requestError->getErrorMessage());
     }


### PR DESCRIPTION
### Reason for change

I wanted to propose another change but I was not comfortable in doing it when the library was not tested with different versions of PHP.

### Code changes

- I replaced the direct usage of `phpunit/phpunit` by `symfony/phpunit-bridge`. That way the tests can be run with different versions of PHPUnit without changing the code.
- I modified one test to fix a deprecation message (`Exception::__construct(): Passing null to parameter #1 ($message) of type string is deprecated`) 

### How to test

Execute a build with this branch.

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [x] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [x] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [x] The tests are relevant, and cover the corner/error cases, not only the happy path
- [x] You understand the impact of this PR on existing code/features

### Non applicable

- [x] The PR implements the changes asked in the referenced task / issue
- [x] The changes include adequate logging and Datadog traces
- [x] Documentation is updated (API, developer documentation, ADR, Notion...)