### PR TITLE
Feat : compatibility psr log 2 and 3 + fix unit tests 

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,5 +1,13 @@
 FROM composer:1 as composer
-FROM php:5.6-fpm
+#FROM php:5.6-fpm
+#FROM php:7.0-fpm
+#FROM php:7.1-fpm
+#FROM php:7.2-fpm
+#FROM php:7.3-fpm
+#FROM php:7.4-fpm
+#FROM php:8.0-fpm
+#FROM php:8.1-fpm
+FROM php:8.2-fpm
 
 # Packages install
 RUN export DEBIAN_FRONTEND=noninteractive \

--- a/.docker/php.ini
+++ b/.docker/php.ini
@@ -518,7 +518,7 @@ report_memleaks = On
 ; Development Value: On
 ; Production Value: Off
 ; http://php.net/track-errors
-track_errors = On
+track_errors = Off
 
 ; Turn off normal error reporting and emit XML-RPC error XML
 ; http://php.net/xmlrpc-errors

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master]
   pull_request:
-    branches: [master, feat/v2-0-0]
+    branches: [master]
   workflow_dispatch: ~
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@
 .idea
 dist/
 composer.lock
-
 phpunit.xml
+.phpunit.cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+v1.11.2
+-------
+* Fix : Compatibility psr/log 1/2/3
+
 v1.11.1
 -------
 * Fix : Check the amount purchase type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 v1.11.2
 -------
 * Fix : Compatibility psr/log 1/2/3
+* Fix : Unit tests and Integration tests for PHP5.6 to PHP8.2
 
 v1.11.1
 -------

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ help:
 ## Docker tests
 ##---------------------------------------------------------------------------
 up: ## Up PHP test container
-	CURRENT_UID=$(id -u):www-data docker-compose -f .docker/docker-compose.yml up -d --build;
+	CURRENT_UID=$(id -u):www-data docker-compose -f .docker/docker-compose.yml up -d --build ;
 
 stop: ## Stop PHP test container
 	CURRENT_UID=$(id -u):www-data docker-compose -f .docker/docker-compose.yml stop;
@@ -19,14 +19,11 @@ remove: ## remove PHP test container
 composer:
 	docker exec -it -u www-data:www-data test-php /usr/bin/composer install
 
-test: up composer ## Execute PHPUnit tests
+unit-test: up composer ## Execute PHPUnit tests
 	docker exec -it -u www-data test-php sh -c './vendor/bin/phpunit --testsuite "Alma PHP Client Unit Test Suite"'
 
 integration-test: up composer ## Execute intregration tests
 	docker exec -it -u www-data test-php sh -c './vendor/bin/phpunit --testsuite "Alma PHP Client Integration Test Suite"'
-
-test-all: up composer ## Execute All PHPUnit tests
-	docker exec -it -u www-data test-php sh -c './vendor/bin/phpunit'
 
 connect: up ## Connect to test container
 	docker exec -it -u www-data:www-data test-php /bin/bash

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
     "phpcompatibility/php-compatibility": "^9.0",
-    "phpunit/phpunit": "*",
+    "phpunit/phpunit": "^5 || ^6 || ^7 || ^8 || ^9 || ^10",
     "roave/security-advisories": "@dev",
     "squizlabs/php_codesniffer": "^3.3",
     "mockery/mockery": "^1.3"

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,11 @@
 {
   "name": "alma/alma-php-client",
   "description": "PHP API client for the Alma payments API",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "type": "library",
   "require": {
     "php": "^5.6 || ~7.0 || ~7.1 || ~7.2 || ~7.3 || ~7.4 || ~8.0 || ~8.1 || ~8.2",
-    "psr/log": "^1.1",
+    "psr/log": "^1 || ^2 || ^3",
     "ext-curl": "*",
     "ext-json": "*"
   },

--- a/phpunit.dist.legacy.xml
+++ b/phpunit.dist.legacy.xml
@@ -8,7 +8,8 @@
          convertNoticesToExceptions  = "true"
          convertWarningsToExceptions = "true"
          processIsolation            = "false"
-         stopOnFailure               = "false">
+         stopOnFailure               = "false"
+         beStrictAboutTestsThatDoNotTestAnything="false">
 
     <testsuites>
         <testsuite name="Alma PHP Client Unit Test Suite">

--- a/phpunit.dist.legacy.xml
+++ b/phpunit.dist.legacy.xml
@@ -8,12 +8,19 @@
          convertNoticesToExceptions  = "true"
          convertWarningsToExceptions = "true"
          processIsolation            = "false"
-         stopOnFailure               = "true">
+         stopOnFailure               = "false">
 
     <testsuites>
-        <testsuite name="Alma PHP Client Unit Test Suite Legacy">
-            <directory>tests/Unit/Legacy</directory>
+        <testsuite name="Alma PHP Client Unit Test Suite">
+            <directory>tests/Unit/{MYVERSION}</directory>
+        </testsuite>
+        <testsuite name="Alma PHP Client Integration Test Suite">
+            <directory>tests/Integration/{MYVERSION}</directory>
         </testsuite>
     </testsuites>
+    <php>
+        <env name="ALMA_API_KEY" value="sk_test_*******"/>
+        <env name="ALMA_API_ROOT" value="alma-api-url"/>
+    </php>
 
 </phpunit>

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -12,12 +12,12 @@
 
     <testsuites>
         <testsuite name="Alma PHP Client Unit Test Suite">
-            <directory>tests/unit</directory>
+            <directory>tests/Unit</directory>
         </testsuite>
     </testsuites>
     <testsuites>
         <testsuite name="Alma PHP Client Integration Test Suite">
-            <directory>tests/integration</directory>
+            <directory>tests/Integration</directory>
         </testsuite>
     </testsuites>
     <php>

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -1,28 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit bootstrap = "vendor/autoload.php"
-         backupGlobals               = "false"
-         backupStaticAttributes      = "false"
-         colors                      = "true"
-         convertErrorsToExceptions   = "true"
-         convertNoticesToExceptions  = "true"
-         convertWarningsToExceptions = "true"
-         processIsolation            = "false"
-         stopOnFailure               = "false">
-
-    <testsuites>
-        <testsuite name="Alma PHP Client Unit Test Suite">
-            <directory>tests/Unit</directory>
-        </testsuite>
-    </testsuites>
-    <testsuites>
-        <testsuite name="Alma PHP Client Integration Test Suite">
-            <directory>tests/Integration</directory>
-        </testsuite>
-    </testsuites>
-    <php>
-        <env name="ALMA_API_KEY" value="sk_test_xxxxxxxxxxxxxxxxxxxxxxxx"/>
-        <env name="ALMA_API_ROOT" value="https://alma.api.url.eu"/>
-    </php>
-
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" beStrictAboutTestsThatDoNotTestAnything="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="Alma PHP Client Unit Test Suite">
+      <directory>tests/Unit/PHP8_1</directory>
+    </testsuite>
+    <testsuite name="Alma PHP Client Integration Test Suite">
+      <directory>tests/Integration/PHP8_1</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="ALMA_API_KEY" value="sk_test_*******"/>
+    <env name="ALMA_API_ROOT" value="alma-api-url"/>
+  </php>
 </phpunit>

--- a/src/Client.php
+++ b/src/Client.php
@@ -27,10 +27,9 @@ namespace Alma\API;
 
 use Alma\API\Endpoints;
 use Alma\API\Lib\ClientOptionsValidator;
-use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 
-class Client implements LoggerAwareInterface
+class Client
 {
     const VERSION = '1.11.0';
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -27,7 +27,6 @@ namespace Alma\API;
 
 use Alma\API\Endpoints;
 use Alma\API\Lib\ClientOptionsValidator;
-use Psr\Log\LoggerInterface;
 
 class Client
 {

--- a/src/Client.php
+++ b/src/Client.php
@@ -154,19 +154,6 @@ class Client
 
         $this->addUserAgentComponent('Alma for PHP', self::VERSION);
     }
-
-    /**
-     * Sets a logger instance on the object.
-     *
-     * @param LoggerInterface $logger
-     *
-     * @return void
-     */
-    public function setLogger(LoggerInterface $logger)
-    {
-        // Simply pass the logger forward to the client context
-        $this->context->setLogger($logger);
-    }
 }
 
 // Keep those here for backward compatibility

--- a/src/Client.php
+++ b/src/Client.php
@@ -30,7 +30,7 @@ use Alma\API\Lib\ClientOptionsValidator;
 
 class Client
 {
-    const VERSION = '1.11.0';
+    const VERSION = '1.11.2';
 
     const LIVE_MODE = 'live';
     const TEST_MODE = 'test';

--- a/src/ClientContext.php
+++ b/src/ClientContext.php
@@ -25,11 +25,10 @@
 
 namespace Alma\API;
 
-use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
-class ClientContext implements LoggerAwareInterface
+class ClientContext
 {
     /** @var string */
     public $apiKey;

--- a/tests/Integration/Legacy/Endpoints/PaymentsTest.php
+++ b/tests/Integration/Legacy/Endpoints/PaymentsTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Alma\API\Tests\Integration\Legacy\Endpoints;
+
+use Alma\API\Client;
+use Alma\API\DependenciesError;
+use Alma\API\ParamsError;
+use Alma\API\RequestError;
+use PHPUnit\Framework\TestCase;
+
+final class PaymentsTest extends TestCase
+{
+    protected static $almaClient;
+
+    /**
+     * @throws DependenciesError
+     * @throws ParamsError
+     */
+    public static function setUpBeforeClass()
+    {
+        self::$almaClient = new Client(
+            $_ENV['ALMA_API_KEY'],
+            ['mode' => 'test', 'api_root' => $_ENV['ALMA_API_ROOT'], 'force_tls' => false]
+        );
+    }
+
+
+    private function paymentData($amount)
+    {
+        return [
+            'payment' => [
+                'purchase_amount' => $amount,
+                'shipping_address' => [
+                    'first_name' => 'Jane',
+                    'last_name' => 'Doe',
+                    'line1' => '2 rue de la rue',
+                    'city' => 'Paris',
+                    'postal_code' => '75002',
+                    'country' => 'FR',
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @param int $amount
+     * @throws RequestError
+     */
+    private function createPayment($amount)
+    {
+        return self::$almaClient->payments->create(self::paymentData($amount));
+    }
+
+
+    /**
+     * @throws RequestError
+     */
+    private function checkEligibility($amount, $eligible)
+    {
+        $eligibility = self::$almaClient->payments->eligibility(self::paymentData($amount));
+        self::assertEquals($eligible, $eligibility->isEligible);
+
+        if (!$eligible) {
+            self::assertArrayHasKey('purchase_amount', $eligibility->reasons);
+            self::assertEquals('invalid_value', $eligibility->reasons['purchase_amount']);
+
+            self::assertArrayHasKey('purchase_amount', $eligibility->constraints);
+            self::assertArrayHasKey('minimum', $eligibility->constraints['purchase_amount']);
+            self::assertArrayHasKey('maximum', $eligibility->constraints['purchase_amount']);
+        }
+    }
+
+    /**
+     * @throws RequestError
+     */
+    public function testCanCheckEligibility()
+    {
+        self::checkEligibility(1, false);
+        self::checkEligibility(20000, true);
+        self::checkEligibility(500000, false);
+    }
+
+    /**
+     * @throws RequestError
+     */
+    public function testCanCreateAPayment()
+    {
+        $payment = self::createPayment(26300);
+        self::assertEquals(26300, $payment->purchase_amount);
+    }
+
+    /**
+     * @throws RequestError
+     */
+    public function testCanFetchAPayment()
+    {
+        $p1 = self::createPayment(26500);
+        $p2 = self::$almaClient->payments->fetch($p1->id);
+
+        self::assertEquals($p1->id, $p2->id);
+    }
+}

--- a/tests/Integration/PHP7_0/Endpoints/PaymentsTest.php
+++ b/tests/Integration/PHP7_0/Endpoints/PaymentsTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Alma\API\Tests\Integration\PHP7_0\Endpoints;
+
+use Alma\API\Client;
+use Alma\API\DependenciesError;
+use Alma\API\ParamsError;
+use Alma\API\RequestError;
+use PHPUnit\Framework\TestCase;
+
+final class PaymentsTest extends TestCase
+{
+    protected static $almaClient;
+
+    /**
+     * @throws DependenciesError
+     * @throws ParamsError
+     */
+    public static function setUpBeforeClass()
+    {
+        self::$almaClient = new Client(
+            $_ENV['ALMA_API_KEY'],
+            ['mode' => 'test', 'api_root' => $_ENV['ALMA_API_ROOT'], 'force_tls' => false]
+        );
+    }
+
+
+    private function paymentData($amount)
+    {
+        return [
+            'payment' => [
+                'purchase_amount' => $amount,
+                'shipping_address' => [
+                    'first_name' => 'Jane',
+                    'last_name' => 'Doe',
+                    'line1' => '2 rue de la rue',
+                    'city' => 'Paris',
+                    'postal_code' => '75002',
+                    'country' => 'FR',
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @param int $amount
+     * @throws RequestError
+     */
+    private function createPayment($amount)
+    {
+        return self::$almaClient->payments->create(self::paymentData($amount));
+    }
+
+
+    /**
+     * @throws RequestError
+     */
+    private function checkEligibility($amount, $eligible)
+    {
+        $eligibility = self::$almaClient->payments->eligibility(self::paymentData($amount));
+        self::assertEquals($eligible, $eligibility->isEligible);
+
+        if (!$eligible) {
+            self::assertArrayHasKey('purchase_amount', $eligibility->reasons);
+            self::assertEquals('invalid_value', $eligibility->reasons['purchase_amount']);
+
+            self::assertArrayHasKey('purchase_amount', $eligibility->constraints);
+            self::assertArrayHasKey('minimum', $eligibility->constraints['purchase_amount']);
+            self::assertArrayHasKey('maximum', $eligibility->constraints['purchase_amount']);
+        }
+    }
+
+    /**
+     * @throws RequestError
+     */
+    public function testCanCheckEligibility()
+    {
+        self::checkEligibility(1, false);
+        self::checkEligibility(20000, true);
+        self::checkEligibility(500000, false);
+    }
+
+    /**
+     * @throws RequestError
+     */
+    public function testCanCreateAPayment()
+    {
+        $payment = self::createPayment(26300);
+        self::assertEquals(26300, $payment->purchase_amount);
+    }
+
+    /**
+     * @throws RequestError
+     */
+    public function testCanFetchAPayment()
+    {
+        $p1 = self::createPayment(26500);
+        $p2 = self::$almaClient->payments->fetch($p1->id);
+
+        self::assertEquals($p1->id, $p2->id);
+    }
+}

--- a/tests/Integration/PHP7_2/Endpoints/PaymentsTest.php
+++ b/tests/Integration/PHP7_2/Endpoints/PaymentsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Alma\API\Tests\Integration\Endpoints;
+namespace Alma\API\Tests\Integration\PHP7_2\Endpoints;
 
 use Alma\API\Client;
 use Alma\API\DependenciesError;
@@ -16,7 +16,7 @@ final class PaymentsTest extends TestCase
      * @throws DependenciesError
      * @throws ParamsError
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
         self::$almaClient = new Client(
             $_ENV['ALMA_API_KEY'],

--- a/tests/Integration/PHP8_1/Endpoints/PaymentsTest.php
+++ b/tests/Integration/PHP8_1/Endpoints/PaymentsTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Alma\API\Tests\Integration\PHP8_1\Endpoints;
+
+use Alma\API\Client;
+use Alma\API\DependenciesError;
+use Alma\API\ParamsError;
+use Alma\API\RequestError;
+use PHPUnit\Framework\TestCase;
+
+final class PaymentsTest extends TestCase
+{
+    protected static $almaClient;
+
+    /**
+     * @throws DependenciesError
+     * @throws ParamsError
+     */
+    public static function setUpBeforeClass() : void
+    {
+        self::$almaClient = new Client(
+            $_ENV['ALMA_API_KEY'],
+            ['mode' => 'test', 'api_root' => $_ENV['ALMA_API_ROOT'], 'force_tls' => false]
+        );
+    }
+
+
+    private function paymentData($amount)
+    {
+        return [
+            'payment' => [
+                'purchase_amount' => $amount,
+                'shipping_address' => [
+                    'first_name' => 'Jane',
+                    'last_name' => 'Doe',
+                    'line1' => '2 rue de la rue',
+                    'city' => 'Paris',
+                    'postal_code' => '75002',
+                    'country' => 'FR',
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @param int $amount
+     * @throws RequestError
+     */
+    private function createPayment($amount)
+    {
+        return self::$almaClient->payments->create(self::paymentData($amount));
+    }
+
+
+    /**
+     * @throws RequestError
+     */
+    private function checkEligibility($amount, $eligible)
+    {
+        $eligibility = self::$almaClient->payments->eligibility(self::paymentData($amount));
+        self::assertEquals($eligible, $eligibility->isEligible);
+
+        if (!$eligible) {
+            self::assertArrayHasKey('purchase_amount', $eligibility->reasons);
+            self::assertEquals('invalid_value', $eligibility->reasons['purchase_amount']);
+
+            self::assertArrayHasKey('purchase_amount', $eligibility->constraints);
+            self::assertArrayHasKey('minimum', $eligibility->constraints['purchase_amount']);
+            self::assertArrayHasKey('maximum', $eligibility->constraints['purchase_amount']);
+        }
+    }
+
+    /**
+     * @throws RequestError
+     */
+    public function testCanCheckEligibility()
+    {
+        self::checkEligibility(1, false);
+        self::checkEligibility(20000, true);
+        self::checkEligibility(500000, false);
+    }
+
+    /**
+     * @throws RequestError
+     */
+    public function testCanCreateAPayment()
+    {
+        $payment = self::createPayment(26300);
+        self::assertEquals(26300, $payment->purchase_amount);
+    }
+
+    /**
+     * @throws RequestError
+     */
+    public function testCanFetchAPayment()
+    {
+        $p1 = self::createPayment(26500);
+        $p2 = self::$almaClient->payments->fetch($p1->id);
+
+        self::assertEquals($p1->id, $p2->id);
+    }
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,27 +1,40 @@
 Alma PHP API client tests
 =====================
 
-To be able to launch the tests you would require to copy `phpunit.dist.xml` to `phpunit.xml`
-and to fill in `ALMA_API_KEY` and `ALMA_API_ROOT`
+You need to change in .docker/Dockerfile ligne 2 your version of PHP
+
+## For PHP 5.6 to 8.0
+- copy `phpunit.dist.leg acy.xml` to `phpunit.xml`
+
+#### If you are using PHP5.6
+
+You need to change in phpunit.xml the variable {MYVERSION} by "Legacy"
+
+#### If you are using PHP7.0 or PHP7.1
+
+You need to change in phpunit.xml the variable {MYVERSION} by "PHP7_0"
+
+#### If you are using PHP7.2 or PHP7.3 or PHP7.4 or PHP8.0
+
+You need to change in phpunit.xml the variable {MYVERSION} by "PHP7_2"
+
+
+## For PHP > 8.0
+- copy `phpunit.dist.xml` to `phpunit.xml`
+
+## For all version
+- fill in `ALMA_API_KEY` and `ALMA_API_ROOT`
+
+
 
 ---------------------
 
-before launching the test, up the container :
-```
-make up
-```
-
 to launch unit test :
 ```
-make test
+make unit-test
 ```
 
 to launch integration test :
 ```
 make integration-test
-```
-
-to launch integration and unit test :
-```
-make test-all
 ```

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,10 +1,8 @@
-Alma PHP API client tests
+Alma PHP API Client tests
 =====================
 
-You need to change in .docker/Dockerfile ligne 2 your version of PHP
-
 ## For PHP 5.6 to 8.0
-- copy `phpunit.dist.leg acy.xml` to `phpunit.xml`
+- copy `phpunit.dist.legacy.xml` to `phpunit.xml`
 
 #### If you are using PHP5.6
 
@@ -24,10 +22,12 @@ You need to change in phpunit.xml the variable {MYVERSION} by "PHP7_2"
 
 ## For all version
 - fill in `ALMA_API_KEY` and `ALMA_API_ROOT`
-
+- Change in .docker/Dockerfile ligne 2 your version of PHP
 
 
 ---------------------
+
+## Launch tests 
 
 to launch unit test :
 ```

--- a/tests/Unit/Legacy/ArrayUtilsTest.php
+++ b/tests/Unit/Legacy/ArrayUtilsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Alma\API\Tests\Unit;
+namespace Alma\API\Tests\Unit\Legacy;
 
 use Alma\API\Lib\ArrayUtils;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Legacy/ClientContextTest.php
+++ b/tests/Unit/Legacy/ClientContextTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Alma\API\Tests\Unit\Legacy;
+
+use Alma\API\ClientContext;
+use PHPUnit\Framework\TestCase;
+use Alma\API\Client;
+use Psr\Log\NullLogger;
+
+/**
+ * Class ClientContextTest
+ */
+class ClientContextTest extends TestCase
+{
+    /** @var string  */
+    const FAKE_API_URI = 'https://fake-api.getalma.eu';
+
+    /**
+     * Return faulty options to test ClientOptionsValidator::validateOptions
+     * @return array
+     */
+    public function getClientconfigOptions()
+    {
+        return [
+            'empty' => [[
+                'api_root' => [
+                    Client::TEST_MODE => self::FAKE_API_URI,
+                    Client::LIVE_MODE => self::FAKE_API_URI
+                ],
+                'force_tls' => 0,
+                'mode' => Client::TEST_MODE,
+                'logger' => new NullLogger()
+            ]],
+            'user_agent_component' => [[
+                'api_root' => [
+                    Client::TEST_MODE => self::FAKE_API_URI,
+                    Client::LIVE_MODE => self::FAKE_API_URI
+                ],
+                'force_tls' => 0,
+                'mode' => Client::TEST_MODE,
+                'logger' => new NullLogger(),
+                'user_agent_component' => ['Magento' => '12.3']
+            ]],
+        ];
+    }
+
+    /**
+     * @dataProvider getClientconfigOptions
+     * @return void
+     * @throws ParamsError
+     */
+    public function testClientContext($options)
+    {
+        $context = new ClientContext("sk_fake_api_key", $options);
+
+        $this->assertInstanceOf(ClientContext::class, $context);
+    }
+}

--- a/tests/Unit/Legacy/ClientOptionsValidatorTest.php
+++ b/tests/Unit/Legacy/ClientOptionsValidatorTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Alma\API\Tests\Unit\Legacy;
+
+use Alma\API\Lib\ClientOptionsValidator;
+use Alma\API\Client;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Alma\API\ParamsError;
+
+/**
+ * Class ClientOptionsValidatorTest
+ */
+class ClientOptionsValidatorTest extends TestCase
+{
+    /** @var string  */
+    const FAKE_API_URI = 'https://fake-api.getalma.eu';
+
+    /**
+     * Return options to test ClientOptionsValidator::validateOptions
+     * @return array
+     */
+    public function getClientOptions()
+    {
+        return [
+            [
+                [],
+                [
+                    'api_root' => [
+                        Client::TEST_MODE => Client::SANDBOX_API_URL,
+                        Client::LIVE_MODE => Client::LIVE_API_URL
+                    ],
+                    'force_tls' => 2,
+                    'mode' => Client::LIVE_MODE,
+                    'logger' => new NullLogger()
+                ]
+            ],
+            [
+                [
+                    'api_root' => [
+                        Client::TEST_MODE => self::FAKE_API_URI,
+                        Client::LIVE_MODE => self::FAKE_API_URI
+                    ],
+                    'force_tls' => 0,
+                    'mode' => Client::TEST_MODE,
+                    'logger' => new NullLogger()
+                ],
+                [
+                    'api_root' => [
+                        Client::TEST_MODE => self::FAKE_API_URI,
+                        Client::LIVE_MODE => self::FAKE_API_URI
+                    ],
+                    'force_tls' => 0,
+                    'mode' => Client::TEST_MODE,
+                    'logger' => new NullLogger()
+                ]
+            ],
+            [
+                [
+                    'api_root' => self::FAKE_API_URI,
+                    'force_tls' => true,
+                    'logger' => new NullLogger()
+                ],
+                [
+                    'api_root' => [
+                        Client::TEST_MODE => self::FAKE_API_URI,
+                        Client::LIVE_MODE => self::FAKE_API_URI
+                    ],
+                    'force_tls' => 2,
+                    'mode' => Client::LIVE_MODE,
+                    'logger' => new NullLogger()
+                ]
+            ],
+            [
+                [
+                    'user_agent_component' => [
+                        'PrestaShop' => 2.3,
+                        'Alma for PrestaShop' => 'v2.3',
+                    ]
+                ],
+                [
+                    'api_root' => [
+                        Client::TEST_MODE => Client::SANDBOX_API_URL,
+                        Client::LIVE_MODE => Client::LIVE_API_URL
+                    ],
+                    'force_tls' => 2,
+                    'mode' => Client::LIVE_MODE,
+                    'logger' => new NullLogger(),
+                    'user_agent_component' => [
+                        'PrestaShop' => 2.3,
+                        'Alma for PrestaShop' => 'v2.3',
+                    ]
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider getClientOptions
+     * @return void
+     * @throws ParamsError
+     */
+    public function testClientOptionsValidator($options, $expectedResult)
+    {
+        $validatedConfig = ClientOptionsValidator::validateOptions($options);
+
+        $this->assertEquals($expectedResult, $validatedConfig);
+    }
+
+    /**
+     * Return faulty options to test ClientOptionsValidator::validateOptions
+     * @return array
+     */
+    public function getInvalidClientOptions()
+    {
+        return [
+            'invalid api_root' => [
+                [
+                    'api_root' => [
+                        'something wrong' => Client::SANDBOX_API_URL,
+                        'something wronger' => Client::LIVE_API_URL
+                    ],
+                ],
+            ],
+            'invalid tls' => [
+                [
+                    'force_tls' => -1,
+                ],
+            ],
+            'invalid mode' => [
+                [
+                    'mode' => 'sad',
+                ],
+            ],
+            'invalid user_agent_component' => [
+                [
+                    'user_agent_component' => [
+                        'I dont give a key:value pair',
+                    ]
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider getInvalidClientOptions
+     * @return void
+     * @throws ParamsError
+     */
+    public function testFaultyClientOptionsValidator($options)
+    {
+        $this->expectException(ParamsError::class);
+        ClientOptionsValidator::validateOptions($options);
+    }
+}

--- a/tests/Unit/Legacy/Endpoints/PaymentsTest.php
+++ b/tests/Unit/Legacy/Endpoints/PaymentsTest.php
@@ -1,0 +1,511 @@
+<?php
+
+namespace Alma\API\Tests\Unit\Legacy\Endpoints;
+
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+use Alma\API\Endpoints\Payments;
+use Alma\API\Lib\ClientOptionsValidator;
+use Alma\API\ClientContext;
+use Alma\API\Request;
+use Alma\API\ParamsError;
+use Alma\API\RequestError;
+
+/**
+ * Class Payments
+ */
+class PaymentsTest extends TestCase
+{
+    const MERCHANT_REF = "merchant_ref";
+
+    /**
+     * Ensure that the methods exists
+     */
+    public function testRefundMethodExist()
+    {
+        $clientContext = Mockery::mock(ClientContext::class);
+
+        $payments = new Payments($clientContext);
+
+        $this->assertEquals(true, method_exists($payments, 'partialRefund'));
+        $this->assertEquals(true, method_exists($payments, 'fullRefund'));
+        # ensure backward compatibility
+        $this->assertEquals(true, method_exists($payments, 'refund'));
+    }
+
+    /**
+     * Mock ClientContext, Response and Request to allow us to test
+     * Payment without sending any requests
+     */
+    private function mockServerRequest()
+    {
+        // ClientContext
+        $clientContext = Mockery::mock(ClientContext::class);
+        $clientContext->shouldReceive('urlFor');
+        $clientContext->shouldReceive('getUserAgentString');
+        $clientContext->shouldReceive('forcedTLSVersion');
+
+        // Response
+        $json = '{
+           "payment_plan":[
+              {
+                 "customer_can_postpone":false,
+                 "customer_fee":100,
+                 "customer_interest":0,
+                 "date_paid":1649672472,
+                 "due_date":1649672451,
+                 "id":"installment_11uPRjPgPJ5jxmEEXxIPPOvVA3Fh7cg13m",
+                 "original_purchase_amount":11733,
+                 "purchase_amount":11733,
+                 "state":"paid"
+              },
+              {
+                 "customer_can_postpone":false,
+                 "customer_fee":0,
+                 "customer_interest":0,
+                 "date_paid":null,
+                 "due_date":1652264451,
+                 "id":"installment_11uPRjP4a3cFQvoM1lehDnpxa2tYm2Hy0I",
+                 "original_purchase_amount":11733,
+                 "purchase_amount":0,
+                 "state":"paid"
+              },
+              {
+                 "customer_can_postpone":false,
+                 "customer_fee":0,
+                 "customer_interest":0,
+                 "date_paid":null,
+                 "due_date":1654942851,
+                 "id":"installment_11uPRjP79fG5QtHO54lSYsnDvyHb56oeCn",
+                 "original_purchase_amount":11733,
+                 "purchase_amount":0,
+                 "state":"paid"
+              }
+           ],
+           "orders":[
+              {
+                 "comment":null,
+                 "created":1649672451,
+                 "customer_url":null,
+                 "data":{},
+                 "id":"order_11uPRjP4L9Dgbttx3cFUKGFPppdZIlrR2V",
+                 "merchant_reference":"00000206",
+                 "merchant_url":null,
+                 "payment":"payment_11uPRjP5FaIYygQao8WdMQFnKRMOV14frx"
+              }
+           ],
+           "refunds":[
+              {
+                 "amount":35299,
+                 "created":1649770695,
+                 "from_payment_cancellation":false,
+                 "id":"refund_11uPrHz4TfHmQrD1OkYyWb4hPuq3673Vqm",
+                 "merchant_reference":null,
+                 "payment":"payment_11uPRjP5FaIYygQao8WdMQFnKRMOV14frx",
+                 "payment_refund_amount":11833,
+                 "rebate_amount":23466
+              }
+           ]
+        }';
+
+        $responseMock = Mockery::mock(Response::class);
+        $responseMock->shouldReceive('isError')->andReturn(false);
+        $responseMock->json = json_decode($json, true);
+
+        // Request
+        $requestMock = Mockery::mock(Request::class);
+        $requestMock->shouldReceive('setRequestBody');
+        $requestMock->shouldReceive('post')->andReturn($responseMock);
+        return $requestMock;
+    }
+
+    /**
+     * Return input to test testPartialRefund
+     * @return array[]
+     */
+    public function getPartialRefundData()
+    {
+        return [
+            [[
+                'id' => "some_id",
+                'amount' => 15000,
+                'merchant_ref' => self::MERCHANT_REF,
+                'comment' => "some comment"
+            ]],
+            [[
+                'id' => "some_id",
+                'amount' => 15000,
+                'merchant_ref' => self::MERCHANT_REF
+            ]],
+            [[
+                'id' => "some_id",
+                'amount' => 15000
+            ]]
+        ];
+    }
+
+    private function callPartialRefund($payments, $data)
+    {
+        if (isset($data['merchant_ref']) && isset($data['comment'])) {
+            $payments->partialRefund($data['id'], $data['amount'], $data['merchant_ref'], $data['comment']);
+        } elseif (isset($data['merchant_ref'])) {
+            $payments->partialRefund($data['id'], $data['amount'], $data['merchant_ref']);
+        } elseif (isset($data['comment'])) {
+            $payments->partialRefund($data['id'], $data['amount'], '', $data['comment']);
+        } else {
+            $payments->partialRefund($data['id'], $data['amount']);
+        }
+    }
+
+    /**
+     * Test the partialRefund method with valid datas
+     * @dataProvider getPartialRefundData
+     * @return void
+     */
+    public function testPartialRefund($data)
+    {
+        $clientContext = Mockery::mock(ClientContext::class);
+
+        // Payment
+        $payments = Mockery::mock(Payments::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial()
+        ;
+        $id = $data['id'];
+        $payments->shouldReceive('request')
+            ->with("/v1/payments/$id/refund")
+            ->once()
+            ->andReturn($this->mockServerRequest())
+        ;
+        $payments->setClientContext($clientContext);
+
+        /* Test */
+        $this->callPartialRefund($payments, $data);
+    }
+
+    /**
+     * Return invalid input to test testPartialRefund
+     * @return array[]
+     */
+    public function getPartialRefundInvalidData()
+    {
+        return [
+            [[
+                'id' => "negative_amount",
+                'amount' => -1
+            ], ParamsError::class],
+            [[
+                'id' => "",
+                'amount' => 1500,
+                'merchant_ref' => "no id",
+            ], ParamsError::class],
+        ];
+    }
+
+    /**
+     * Test the partialRefund method with valid datas
+     * @dataProvider getPartialRefundInvalidData
+     * @return void
+     */
+    public function testInvalidPartialRefund($data, $expectedException)
+    {
+        $clientContext = Mockery::mock(ClientContext::class);
+
+        // Payment
+        $payments = Mockery::mock(Payments::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial()
+        ;
+        $id = $data['id'];
+        $payments->shouldReceive('request')
+            ->with("/v1/payments/$id/refund")
+            ->andReturn($this->mockServerRequest())
+        ;
+        $payments->setClientContext($clientContext);
+
+        $this->expectException($expectedException);
+
+        /* Test */
+        $this->callPartialRefund($payments, $data);
+    }
+
+
+    private function callFullRefund($payments, $data)
+    {
+        if (isset($data['merchant_ref']) && isset($data['comment'])) {
+            $payments->fullRefund($data['id'], $data['merchant_ref'], $data['comment']);
+        } elseif (isset($data['merchant_ref'])) {
+            $payments->fullRefund($data['id'], $data['merchant_ref']);
+        } elseif (isset($data['comment'])) {
+            $payments->fullRefund($data['id'], '', $data['comment']);
+        } else {
+            $payments->fullRefund($data['id']);
+        }
+    }
+
+    /**
+     * Return input to test testFullRefund
+     * @return array[]
+     */
+    public function getFullRefundData()
+    {
+        return [
+            [[
+                'id' => "some_id",
+                'merchant_ref' => self::MERCHANT_REF,
+                'comment' => "some comment"
+            ]],
+            [[
+                'id' => "some_id",
+                'merchant_ref' => self::MERCHANT_REF
+            ]],
+            [[
+                'id' => "some_id",
+            ]]
+        ];
+    }
+
+    /**
+     * Test the fullRefund method with valid datas
+     * @dataProvider getFullRefundData
+     * @return void
+     */
+    public function testFullRefund($data)
+    {
+        $clientContext = Mockery::mock(ClientContext::class);
+
+        // Payment
+        $payments = Mockery::mock(Payments::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial()
+        ;
+        $id = $data['id'];
+        $payments->shouldReceive('request')
+            ->with("/v1/payments/$id/refund")
+            ->once()
+            ->andReturn($this->mockServerRequest())
+        ;
+        $payments->setClientContext($clientContext);
+
+        /* Test */
+        $this->callFullRefund($payments, $data);
+    }
+
+    /**
+     * Return input to test testRefund
+     * @return array[]
+     */
+    public function getRefundData()
+    {
+        return [
+            [[
+                'id' => "some_id",
+                'amount' => 15000,
+                'merchant_ref' => self::MERCHANT_REF,
+            ]],
+            [[
+                'id' => "some_id",
+            ]],
+            [[
+                'id' => "some_id",
+                'amount' => 15000
+            ]]
+        ];
+    }
+
+    private function callRefund($payments, $data)
+    {
+        if (isset($data['merchant_ref']) && isset($data['amount'])) {
+            $payments->refund($data['id'], $data['amount'], $data['merchant_ref']);
+        } elseif (isset($data['amount'])) {
+            $payments->refund($data['id'], $data['amount']);
+        } else {
+            $payments->refund($data['id']);
+        }
+    }
+
+    /**
+     * Test the fullRefund method with valid datas
+     * Important to ensure we didn't break compatibility with 1.x.x versions
+     * @dataProvider getRefundData
+     * @return void
+     */
+    public function testRefund($data)
+    {
+        $clientContext = Mockery::mock(ClientContext::class);
+
+        // Payment
+        $payments = Mockery::mock(Payments::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial()
+        ;
+        $id = $data['id'];
+        $payments->shouldReceive('request')
+            ->with("/v1/payments/$id/refund")
+            ->once()
+            ->andReturn($this->mockServerRequest())
+        ;
+        $payments->setClientContext($clientContext);
+
+        /* Test */
+        $this->callRefund($payments, $data);
+    }
+
+    /**
+     * Return invalid input to test testFullRefund
+     * @return array[]
+     */
+    public function getFullRefundInvalidData()
+    {
+        return [
+            [[
+                'id' => "",
+                'merchant_ref' => "no id",
+            ], ParamsError::class],
+        ];
+    }
+
+    /**
+     * Test the fullRefund method with valid datas
+     * @dataProvider getFullRefundInvalidData
+     * @return void
+     */
+    public function testInvalidFullRefund($data, $expectedException)
+    {
+        $clientContext = Mockery::mock(ClientContext::class);
+
+        // Payment
+        $payments = Mockery::mock(Payments::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial()
+        ;
+        $id = $data['id'];
+        $payments->shouldReceive('request')
+            ->with("/v1/payments/$id/refund")
+            ->andReturn($this->mockServerRequest())
+        ;
+        $payments->setClientContext($clientContext);
+
+        $this->expectException($expectedException);
+
+        /* Test */
+        $this->callFullRefund($payments, $data);
+    }
+
+    /**
+     * Mock ClientContext, Response and Request to allow us to test
+     * Payment without sending any requests but returns an error
+     */
+    private function mockServerRequestError()
+    {
+        // ClientContext
+        $clientContext = Mockery::mock(ClientContext::class);
+        $clientContext->shouldReceive('urlFor');
+        $clientContext->shouldReceive('getUserAgentString');
+        $clientContext->shouldReceive('forcedTLSVersion');
+
+        // Response
+        $json = '{
+           "payment_plan":[
+              {
+                 "customer_can_postpone":false,
+                 "customer_fee":100,
+                 "customer_interest":0,
+                 "date_paid":1649672472,
+                 "due_date":1649672451,
+                 "id":"installment_11uPRjPgPJ5jxmEEXxIPPOvVA3Fh7cg13m",
+                 "original_purchase_amount":11733,
+                 "purchase_amount":11733,
+                 "state":"paid"
+              },
+              {
+                 "customer_can_postpone":false,
+                 "customer_fee":0,
+                 "customer_interest":0,
+                 "date_paid":null,
+                 "due_date":1652264451,
+                 "id":"installment_11uPRjP4a3cFQvoM1lehDnpxa2tYm2Hy0I",
+                 "original_purchase_amount":11733,
+                 "purchase_amount":0,
+                 "state":"paid"
+              },
+              {
+                 "customer_can_postpone":false,
+                 "customer_fee":0,
+                 "customer_interest":0,
+                 "date_paid":null,
+                 "due_date":1654942851,
+                 "id":"installment_11uPRjP79fG5QtHO54lSYsnDvyHb56oeCn",
+                 "original_purchase_amount":11733,
+                 "purchase_amount":0,
+                 "state":"paid"
+              }
+           ],
+           "orders":[
+              {
+                 "comment":null,
+                 "created":1649672451,
+                 "customer_url":null,
+                 "data":{},
+                 "id":"order_11uPRjP4L9Dgbttx3cFUKGFPppdZIlrR2V",
+                 "merchant_reference":"00000206",
+                 "merchant_url":null,
+                 "payment":"payment_11uPRjP5FaIYygQao8WdMQFnKRMOV14frx"
+              }
+           ],
+           "refunds":[
+              {
+                 "amount":35299,
+                 "created":1649770695,
+                 "from_payment_cancellation":false,
+                 "id":"refund_11uPrHz4TfHmQrD1OkYyWb4hPuq3673Vqm",
+                 "merchant_reference":null,
+                 "payment":"payment_11uPRjP5FaIYygQao8WdMQFnKRMOV14frx",
+                 "payment_refund_amount":11833,
+                 "rebate_amount":23466
+              }
+           ]
+        }';
+
+        $responseMock = Mockery::mock(Response::class);
+        $responseMock->shouldReceive('isError')->andReturn(true);
+        $responseMock->json = json_decode($json, true);
+        $responseMock->errorMessage = "a very important error message";
+
+        // Request
+        $requestMock = Mockery::mock(Request::class);
+        $requestMock->shouldReceive('setRequestBody');
+        $requestMock->shouldReceive('post')->andReturn($responseMock);
+        return $requestMock;
+    }
+
+    public function testFullRefundRequestError()
+    {
+        // Input
+        $clientContext = Mockery::mock(ClientContext::class);
+        $id = "some_id";
+
+        // Payment
+        $payments = Mockery::mock(Payments::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial()
+        ;
+        $payments->shouldReceive('request')
+            ->with("/v1/payments/$id/refund")
+            ->once()
+            ->andReturn($this->mockServerRequestError())
+        ;
+        $payments->setClientContext($clientContext);
+
+        $this->expectException(RequestError::class);
+
+        /* Test */
+        $payments->fullRefund($id);
+    }
+
+    public function tearDown()
+    {
+        Mockery::close();
+    }
+}

--- a/tests/Unit/Legacy/RequestErrorTest.php
+++ b/tests/Unit/Legacy/RequestErrorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Alma\API\Tests\Unit;
+namespace Alma\API\Tests\Unit\Legacy;
 
 use PHPUnit\Framework\TestCase;
 use Alma\API\Response;

--- a/tests/Unit/PHP7_0/ArrayUtilsTest.php
+++ b/tests/Unit/PHP7_0/ArrayUtilsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Alma\API\Tests\Unit\PHP7_0;
+
+use Alma\API\Lib\ArrayUtils;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class ArrayUtils
+ */
+class ArrayUtilsTest extends TestCase
+{
+    /**
+     * Return options to test ArrayUtils::isAssocArray
+     * @return array[]
+     */
+    public function getTestArrays()
+    {
+        return [
+            [['a', 'b', 'c'], false],
+            [["0" => 'a', "1" => 'b', "2" => 'c'], false],
+            [["1" => 'a', "0" => 'b', "2" => 'c'], false],
+            [["a" => 'a', "b" => 'b', "c" => 'c'], true],
+        ];
+    }
+
+    /**
+     * @dataProvider getTestArrays
+     * @return void
+     */
+    public function testIsAssocArray($testArray, $expectedResult)
+    {
+        $result = ArrayUtils::isAssocArray($testArray);
+        $this->assertEquals($expectedResult, $result);
+    }
+}

--- a/tests/Unit/PHP7_0/ClientContextTest.php
+++ b/tests/Unit/PHP7_0/ClientContextTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Alma\API\Tests\Unit\PHP7_0;
+
+use Alma\API\ClientContext;
+use PHPUnit\Framework\TestCase;
+use Alma\API\Client;
+use Psr\Log\NullLogger;
+
+/**
+ * Class ClientContextTest
+ */
+class ClientContextTest extends TestCase
+{
+    /** @var string  */
+    const FAKE_API_URI = 'https://fake-api.getalma.eu';
+
+    /**
+     * Return faulty options to test ClientOptionsValidator::validateOptions
+     * @return array
+     */
+    public function getClientconfigOptions()
+    {
+        return [
+            'empty' => [[
+                'api_root' => [
+                    Client::TEST_MODE => self::FAKE_API_URI,
+                    Client::LIVE_MODE => self::FAKE_API_URI
+                ],
+                'force_tls' => 0,
+                'mode' => Client::TEST_MODE,
+                'logger' => new NullLogger()
+            ]],
+            'user_agent_component' => [[
+                'api_root' => [
+                    Client::TEST_MODE => self::FAKE_API_URI,
+                    Client::LIVE_MODE => self::FAKE_API_URI
+                ],
+                'force_tls' => 0,
+                'mode' => Client::TEST_MODE,
+                'logger' => new NullLogger(),
+                'user_agent_component' => ['Magento' => '12.3']
+            ]],
+        ];
+    }
+
+    /**
+     * @dataProvider getClientconfigOptions
+     * @return void
+     * @throws ParamsError
+     */
+    public function testClientContext($options)
+    {
+        $context = new ClientContext("sk_fake_api_key", $options);
+
+        $this->assertInstanceOf(ClientContext::class, $context);
+    }
+}

--- a/tests/Unit/PHP7_0/ClientOptionsValidatorTest.php
+++ b/tests/Unit/PHP7_0/ClientOptionsValidatorTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Alma\API\Tests\Unit\PHP7_0;
+
+use Alma\API\Lib\ClientOptionsValidator;
+use Alma\API\Client;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Alma\API\ParamsError;
+
+/**
+ * Class ClientOptionsValidatorTest
+ */
+class ClientOptionsValidatorTest extends TestCase
+{
+    /** @var string  */
+    const FAKE_API_URI = 'https://fake-api.getalma.eu';
+
+    /**
+     * Return options to test ClientOptionsValidator::validateOptions
+     * @return array
+     */
+    public function getClientOptions()
+    {
+        return [
+            [
+                [],
+                [
+                    'api_root' => [
+                        Client::TEST_MODE => Client::SANDBOX_API_URL,
+                        Client::LIVE_MODE => Client::LIVE_API_URL
+                    ],
+                    'force_tls' => 2,
+                    'mode' => Client::LIVE_MODE,
+                    'logger' => new NullLogger()
+                ]
+            ],
+            [
+                [
+                    'api_root' => [
+                        Client::TEST_MODE => self::FAKE_API_URI,
+                        Client::LIVE_MODE => self::FAKE_API_URI
+                    ],
+                    'force_tls' => 0,
+                    'mode' => Client::TEST_MODE,
+                    'logger' => new NullLogger()
+                ],
+                [
+                    'api_root' => [
+                        Client::TEST_MODE => self::FAKE_API_URI,
+                        Client::LIVE_MODE => self::FAKE_API_URI
+                    ],
+                    'force_tls' => 0,
+                    'mode' => Client::TEST_MODE,
+                    'logger' => new NullLogger()
+                ]
+            ],
+            [
+                [
+                    'api_root' => self::FAKE_API_URI,
+                    'force_tls' => true,
+                    'logger' => new NullLogger()
+                ],
+                [
+                    'api_root' => [
+                        Client::TEST_MODE => self::FAKE_API_URI,
+                        Client::LIVE_MODE => self::FAKE_API_URI
+                    ],
+                    'force_tls' => 2,
+                    'mode' => Client::LIVE_MODE,
+                    'logger' => new NullLogger()
+                ]
+            ],
+            [
+                [
+                    'user_agent_component' => [
+                        'PrestaShop' => 2.3,
+                        'Alma for PrestaShop' => 'v2.3',
+                    ]
+                ],
+                [
+                    'api_root' => [
+                        Client::TEST_MODE => Client::SANDBOX_API_URL,
+                        Client::LIVE_MODE => Client::LIVE_API_URL
+                    ],
+                    'force_tls' => 2,
+                    'mode' => Client::LIVE_MODE,
+                    'logger' => new NullLogger(),
+                    'user_agent_component' => [
+                        'PrestaShop' => 2.3,
+                        'Alma for PrestaShop' => 'v2.3',
+                    ]
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider getClientOptions
+     * @return void
+     * @throws ParamsError
+     */
+    public function testClientOptionsValidator($options, $expectedResult)
+    {
+        $validatedConfig = ClientOptionsValidator::validateOptions($options);
+
+        $this->assertEquals($expectedResult, $validatedConfig);
+    }
+
+    /**
+     * Return faulty options to test ClientOptionsValidator::validateOptions
+     * @return array
+     */
+    public function getInvalidClientOptions()
+    {
+        return [
+            'invalid api_root' => [
+                [
+                    'api_root' => [
+                        'something wrong' => Client::SANDBOX_API_URL,
+                        'something wronger' => Client::LIVE_API_URL
+                    ],
+                ],
+            ],
+            'invalid tls' => [
+                [
+                    'force_tls' => -1,
+                ],
+            ],
+            'invalid mode' => [
+                [
+                    'mode' => 'sad',
+                ],
+            ],
+            'invalid user_agent_component' => [
+                [
+                    'user_agent_component' => [
+                        'I dont give a key:value pair',
+                    ]
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider getInvalidClientOptions
+     * @return void
+     * @throws ParamsError
+     */
+    public function testFaultyClientOptionsValidator($options)
+    {
+        $this->expectException(ParamsError::class);
+        ClientOptionsValidator::validateOptions($options);
+    }
+}

--- a/tests/Unit/PHP7_0/Endpoints/PaymentsTest.php
+++ b/tests/Unit/PHP7_0/Endpoints/PaymentsTest.php
@@ -1,0 +1,511 @@
+<?php
+
+namespace Alma\API\Tests\Unit\PHP7_0\Endpoints;
+
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+use Alma\API\Endpoints\Payments;
+use Alma\API\Lib\ClientOptionsValidator;
+use Alma\API\ClientContext;
+use Alma\API\Request;
+use Alma\API\ParamsError;
+use Alma\API\RequestError;
+
+/**
+ * Class Payments
+ */
+class PaymentsTest extends TestCase
+{
+    const MERCHANT_REF = "merchant_ref";
+
+    /**
+     * Ensure that the methods exists
+     */
+    public function testRefundMethodExist()
+    {
+        $clientContext = Mockery::mock(ClientContext::class);
+
+        $payments = new Payments($clientContext);
+
+        $this->assertEquals(true, method_exists($payments, 'partialRefund'));
+        $this->assertEquals(true, method_exists($payments, 'fullRefund'));
+        # ensure backward compatibility
+        $this->assertEquals(true, method_exists($payments, 'refund'));
+    }
+
+    /**
+     * Mock ClientContext, Response and Request to allow us to test
+     * Payment without sending any requests
+     */
+    private function mockServerRequest()
+    {
+        // ClientContext
+        $clientContext = Mockery::mock(ClientContext::class);
+        $clientContext->shouldReceive('urlFor');
+        $clientContext->shouldReceive('getUserAgentString');
+        $clientContext->shouldReceive('forcedTLSVersion');
+
+        // Response
+        $json = '{
+           "payment_plan":[
+              {
+                 "customer_can_postpone":false,
+                 "customer_fee":100,
+                 "customer_interest":0,
+                 "date_paid":1649672472,
+                 "due_date":1649672451,
+                 "id":"installment_11uPRjPgPJ5jxmEEXxIPPOvVA3Fh7cg13m",
+                 "original_purchase_amount":11733,
+                 "purchase_amount":11733,
+                 "state":"paid"
+              },
+              {
+                 "customer_can_postpone":false,
+                 "customer_fee":0,
+                 "customer_interest":0,
+                 "date_paid":null,
+                 "due_date":1652264451,
+                 "id":"installment_11uPRjP4a3cFQvoM1lehDnpxa2tYm2Hy0I",
+                 "original_purchase_amount":11733,
+                 "purchase_amount":0,
+                 "state":"paid"
+              },
+              {
+                 "customer_can_postpone":false,
+                 "customer_fee":0,
+                 "customer_interest":0,
+                 "date_paid":null,
+                 "due_date":1654942851,
+                 "id":"installment_11uPRjP79fG5QtHO54lSYsnDvyHb56oeCn",
+                 "original_purchase_amount":11733,
+                 "purchase_amount":0,
+                 "state":"paid"
+              }
+           ],
+           "orders":[
+              {
+                 "comment":null,
+                 "created":1649672451,
+                 "customer_url":null,
+                 "data":{},
+                 "id":"order_11uPRjP4L9Dgbttx3cFUKGFPppdZIlrR2V",
+                 "merchant_reference":"00000206",
+                 "merchant_url":null,
+                 "payment":"payment_11uPRjP5FaIYygQao8WdMQFnKRMOV14frx"
+              }
+           ],
+           "refunds":[
+              {
+                 "amount":35299,
+                 "created":1649770695,
+                 "from_payment_cancellation":false,
+                 "id":"refund_11uPrHz4TfHmQrD1OkYyWb4hPuq3673Vqm",
+                 "merchant_reference":null,
+                 "payment":"payment_11uPRjP5FaIYygQao8WdMQFnKRMOV14frx",
+                 "payment_refund_amount":11833,
+                 "rebate_amount":23466
+              }
+           ]
+        }';
+
+        $responseMock = Mockery::mock(Response::class);
+        $responseMock->shouldReceive('isError')->andReturn(false);
+        $responseMock->json = json_decode($json, true);
+
+        // Request
+        $requestMock = Mockery::mock(Request::class);
+        $requestMock->shouldReceive('setRequestBody');
+        $requestMock->shouldReceive('post')->andReturn($responseMock);
+        return $requestMock;
+    }
+
+    /**
+     * Return input to test testPartialRefund
+     * @return array[]
+     */
+    public function getPartialRefundData()
+    {
+        return [
+            [[
+                'id' => "some_id",
+                'amount' => 15000,
+                'merchant_ref' => self::MERCHANT_REF,
+                'comment' => "some comment"
+            ]],
+            [[
+                'id' => "some_id",
+                'amount' => 15000,
+                'merchant_ref' => self::MERCHANT_REF
+            ]],
+            [[
+                'id' => "some_id",
+                'amount' => 15000
+            ]]
+        ];
+    }
+
+    private function callPartialRefund($payments, $data)
+    {
+        if (isset($data['merchant_ref']) && isset($data['comment'])) {
+            $payments->partialRefund($data['id'], $data['amount'], $data['merchant_ref'], $data['comment']);
+        } elseif (isset($data['merchant_ref'])) {
+            $payments->partialRefund($data['id'], $data['amount'], $data['merchant_ref']);
+        } elseif (isset($data['comment'])) {
+            $payments->partialRefund($data['id'], $data['amount'], '', $data['comment']);
+        } else {
+            $payments->partialRefund($data['id'], $data['amount']);
+        }
+    }
+
+    /**
+     * Test the partialRefund method with valid datas
+     * @dataProvider getPartialRefundData
+     * @return void
+     */
+    public function testPartialRefund($data)
+    {
+        $clientContext = Mockery::mock(ClientContext::class);
+
+        // Payment
+        $payments = Mockery::mock(Payments::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial()
+        ;
+        $id = $data['id'];
+        $payments->shouldReceive('request')
+            ->with("/v1/payments/$id/refund")
+            ->once()
+            ->andReturn($this->mockServerRequest())
+        ;
+        $payments->setClientContext($clientContext);
+
+        /* Test */
+        $this->callPartialRefund($payments, $data);
+    }
+
+    /**
+     * Return invalid input to test testPartialRefund
+     * @return array[]
+     */
+    public function getPartialRefundInvalidData()
+    {
+        return [
+            [[
+                'id' => "negative_amount",
+                'amount' => -1
+            ], ParamsError::class],
+            [[
+                'id' => "",
+                'amount' => 1500,
+                'merchant_ref' => "no id",
+            ], ParamsError::class],
+        ];
+    }
+
+    /**
+     * Test the partialRefund method with valid datas
+     * @dataProvider getPartialRefundInvalidData
+     * @return void
+     */
+    public function testInvalidPartialRefund($data, $expectedException)
+    {
+        $clientContext = Mockery::mock(ClientContext::class);
+
+        // Payment
+        $payments = Mockery::mock(Payments::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial()
+        ;
+        $id = $data['id'];
+        $payments->shouldReceive('request')
+            ->with("/v1/payments/$id/refund")
+            ->andReturn($this->mockServerRequest())
+        ;
+        $payments->setClientContext($clientContext);
+
+        $this->expectException($expectedException);
+
+        /* Test */
+        $this->callPartialRefund($payments, $data);
+    }
+
+
+    private function callFullRefund($payments, $data)
+    {
+        if (isset($data['merchant_ref']) && isset($data['comment'])) {
+            $payments->fullRefund($data['id'], $data['merchant_ref'], $data['comment']);
+        } elseif (isset($data['merchant_ref'])) {
+            $payments->fullRefund($data['id'], $data['merchant_ref']);
+        } elseif (isset($data['comment'])) {
+            $payments->fullRefund($data['id'], '', $data['comment']);
+        } else {
+            $payments->fullRefund($data['id']);
+        }
+    }
+
+    /**
+     * Return input to test testFullRefund
+     * @return array[]
+     */
+    public function getFullRefundData()
+    {
+        return [
+            [[
+                'id' => "some_id",
+                'merchant_ref' => self::MERCHANT_REF,
+                'comment' => "some comment"
+            ]],
+            [[
+                'id' => "some_id",
+                'merchant_ref' => self::MERCHANT_REF
+            ]],
+            [[
+                'id' => "some_id",
+            ]]
+        ];
+    }
+
+    /**
+     * Test the fullRefund method with valid datas
+     * @dataProvider getFullRefundData
+     * @return void
+     */
+    public function testFullRefund($data)
+    {
+        $clientContext = Mockery::mock(ClientContext::class);
+
+        // Payment
+        $payments = Mockery::mock(Payments::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial()
+        ;
+        $id = $data['id'];
+        $payments->shouldReceive('request')
+            ->with("/v1/payments/$id/refund")
+            ->once()
+            ->andReturn($this->mockServerRequest())
+        ;
+        $payments->setClientContext($clientContext);
+
+        /* Test */
+        $this->callFullRefund($payments, $data);
+    }
+
+    /**
+     * Return input to test testRefund
+     * @return array[]
+     */
+    public function getRefundData()
+    {
+        return [
+            [[
+                'id' => "some_id",
+                'amount' => 15000,
+                'merchant_ref' => self::MERCHANT_REF,
+            ]],
+            [[
+                'id' => "some_id",
+            ]],
+            [[
+                'id' => "some_id",
+                'amount' => 15000
+            ]]
+        ];
+    }
+
+    private function callRefund($payments, $data)
+    {
+        if (isset($data['merchant_ref']) && isset($data['amount'])) {
+            $payments->refund($data['id'], $data['amount'], $data['merchant_ref']);
+        } elseif (isset($data['amount'])) {
+            $payments->refund($data['id'], $data['amount']);
+        } else {
+            $payments->refund($data['id']);
+        }
+    }
+
+    /**
+     * Test the fullRefund method with valid datas
+     * Important to ensure we didn't break compatibility with 1.x.x versions
+     * @dataProvider getRefundData
+     * @return void
+     */
+    public function testRefund($data)
+    {
+        $clientContext = Mockery::mock(ClientContext::class);
+
+        // Payment
+        $payments = Mockery::mock(Payments::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial()
+        ;
+        $id = $data['id'];
+        $payments->shouldReceive('request')
+            ->with("/v1/payments/$id/refund")
+            ->once()
+            ->andReturn($this->mockServerRequest())
+        ;
+        $payments->setClientContext($clientContext);
+
+        /* Test */
+        $this->callRefund($payments, $data);
+    }
+
+    /**
+     * Return invalid input to test testFullRefund
+     * @return array[]
+     */
+    public function getFullRefundInvalidData()
+    {
+        return [
+            [[
+                'id' => "",
+                'merchant_ref' => "no id",
+            ], ParamsError::class],
+        ];
+    }
+
+    /**
+     * Test the fullRefund method with valid datas
+     * @dataProvider getFullRefundInvalidData
+     * @return void
+     */
+    public function testInvalidFullRefund($data, $expectedException)
+    {
+        $clientContext = Mockery::mock(ClientContext::class);
+
+        // Payment
+        $payments = Mockery::mock(Payments::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial()
+        ;
+        $id = $data['id'];
+        $payments->shouldReceive('request')
+            ->with("/v1/payments/$id/refund")
+            ->andReturn($this->mockServerRequest())
+        ;
+        $payments->setClientContext($clientContext);
+
+        $this->expectException($expectedException);
+
+        /* Test */
+        $this->callFullRefund($payments, $data);
+    }
+
+    /**
+     * Mock ClientContext, Response and Request to allow us to test
+     * Payment without sending any requests but returns an error
+     */
+    private function mockServerRequestError()
+    {
+        // ClientContext
+        $clientContext = Mockery::mock(ClientContext::class);
+        $clientContext->shouldReceive('urlFor');
+        $clientContext->shouldReceive('getUserAgentString');
+        $clientContext->shouldReceive('forcedTLSVersion');
+
+        // Response
+        $json = '{
+           "payment_plan":[
+              {
+                 "customer_can_postpone":false,
+                 "customer_fee":100,
+                 "customer_interest":0,
+                 "date_paid":1649672472,
+                 "due_date":1649672451,
+                 "id":"installment_11uPRjPgPJ5jxmEEXxIPPOvVA3Fh7cg13m",
+                 "original_purchase_amount":11733,
+                 "purchase_amount":11733,
+                 "state":"paid"
+              },
+              {
+                 "customer_can_postpone":false,
+                 "customer_fee":0,
+                 "customer_interest":0,
+                 "date_paid":null,
+                 "due_date":1652264451,
+                 "id":"installment_11uPRjP4a3cFQvoM1lehDnpxa2tYm2Hy0I",
+                 "original_purchase_amount":11733,
+                 "purchase_amount":0,
+                 "state":"paid"
+              },
+              {
+                 "customer_can_postpone":false,
+                 "customer_fee":0,
+                 "customer_interest":0,
+                 "date_paid":null,
+                 "due_date":1654942851,
+                 "id":"installment_11uPRjP79fG5QtHO54lSYsnDvyHb56oeCn",
+                 "original_purchase_amount":11733,
+                 "purchase_amount":0,
+                 "state":"paid"
+              }
+           ],
+           "orders":[
+              {
+                 "comment":null,
+                 "created":1649672451,
+                 "customer_url":null,
+                 "data":{},
+                 "id":"order_11uPRjP4L9Dgbttx3cFUKGFPppdZIlrR2V",
+                 "merchant_reference":"00000206",
+                 "merchant_url":null,
+                 "payment":"payment_11uPRjP5FaIYygQao8WdMQFnKRMOV14frx"
+              }
+           ],
+           "refunds":[
+              {
+                 "amount":35299,
+                 "created":1649770695,
+                 "from_payment_cancellation":false,
+                 "id":"refund_11uPrHz4TfHmQrD1OkYyWb4hPuq3673Vqm",
+                 "merchant_reference":null,
+                 "payment":"payment_11uPRjP5FaIYygQao8WdMQFnKRMOV14frx",
+                 "payment_refund_amount":11833,
+                 "rebate_amount":23466
+              }
+           ]
+        }';
+
+        $responseMock = Mockery::mock(Response::class);
+        $responseMock->shouldReceive('isError')->andReturn(true);
+        $responseMock->json = json_decode($json, true);
+        $responseMock->errorMessage = "a very important error message";
+
+        // Request
+        $requestMock = Mockery::mock(Request::class);
+        $requestMock->shouldReceive('setRequestBody');
+        $requestMock->shouldReceive('post')->andReturn($responseMock);
+        return $requestMock;
+    }
+
+    public function testFullRefundRequestError()
+    {
+        // Input
+        $clientContext = Mockery::mock(ClientContext::class);
+        $id = "some_id";
+
+        // Payment
+        $payments = Mockery::mock(Payments::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial()
+        ;
+        $payments->shouldReceive('request')
+            ->with("/v1/payments/$id/refund")
+            ->once()
+            ->andReturn($this->mockServerRequestError())
+        ;
+        $payments->setClientContext($clientContext);
+
+        $this->expectException(RequestError::class);
+
+        /* Test */
+        $payments->fullRefund($id);
+    }
+
+    public function tearDown()
+    {
+        Mockery::close();
+    }
+}

--- a/tests/Unit/PHP7_0/RequestErrorTest.php
+++ b/tests/Unit/PHP7_0/RequestErrorTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Alma\API\Tests\Unit\PHP7_0;
+
+use PHPUnit\Framework\TestCase;
+use Alma\API\Response;
+use Alma\API\RequestError;
+use Mockery;
+use Psr\Log\NullLogger;
+
+/**
+ * Class RequestErrorTest
+ */
+class RequestErrorTest extends TestCase
+{
+
+    /**
+     * Return faulty options to test ClientOptionsValidator::validateOptions
+     * @return array
+     */
+    public function getErrorMessageProvider()
+    {
+        $validExpected = 'some error message';
+        $validResponse = Mockery::mock(Response::class);
+        $validResponse->errorMessage = $validExpected;
+
+        $noMessageExpected = 'error message hidden in response';
+        $noMessageResponse = Mockery::mock(Response::class);
+        $noMessageResponse->errorMessage = null;
+        $noMessageResponse->json = [
+            'errors' => [
+                0 => [
+                    'message' => $noMessageExpected
+                ]
+            ]
+        ];
+
+        return [
+            'valid example' => [
+                null, $validResponse, $validExpected,
+            ],
+            'error message hidden in response' => [
+                null, $noMessageResponse, $noMessageExpected,
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider getErrorMessageProvider
+     * @return void
+     * @throws ParamsError
+     */
+    public function testGetErrorMessage($req, $res, $expected)
+    {
+        $requestError = new RequestError($res->errorMessage, $req, $res);
+
+        $this->assertEquals($expected, $requestError->getErrorMessage());
+    }
+}

--- a/tests/Unit/PHP7_2/ArrayUtilsTest.php
+++ b/tests/Unit/PHP7_2/ArrayUtilsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Alma\API\Tests\Unit\PHP7_2;
+
+use Alma\API\Lib\ArrayUtils;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class ArrayUtils
+ */
+class ArrayUtilsTest extends TestCase
+{
+    /**
+     * Return options to test ArrayUtils::isAssocArray
+     * @return array[]
+     */
+    public function getTestArrays()
+    {
+        return [
+            [['a', 'b', 'c'], false],
+            [["0" => 'a', "1" => 'b', "2" => 'c'], false],
+            [["1" => 'a', "0" => 'b', "2" => 'c'], false],
+            [["a" => 'a', "b" => 'b', "c" => 'c'], true],
+        ];
+    }
+
+    /**
+     * @dataProvider getTestArrays
+     * @return void
+     */
+    public function testIsAssocArray($testArray, $expectedResult)
+    {
+        $result = ArrayUtils::isAssocArray($testArray);
+        $this->assertEquals($expectedResult, $result);
+    }
+}

--- a/tests/Unit/PHP7_2/ClientContextTest.php
+++ b/tests/Unit/PHP7_2/ClientContextTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Alma\API\Tests\Unit;
+namespace Alma\API\Tests\Unit\PHP7_2;
 
 use Alma\API\ClientContext;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/PHP7_2/ClientOptionsValidatorTest.php
+++ b/tests/Unit/PHP7_2/ClientOptionsValidatorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Alma\API\Tests\Unit;
+namespace Alma\API\Tests\Unit\PHP7_2;
 
 use Alma\API\Lib\ClientOptionsValidator;
 use Alma\API\Client;

--- a/tests/Unit/PHP7_2/Endpoints/PaymentsTest.php
+++ b/tests/Unit/PHP7_2/Endpoints/PaymentsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Alma\API\Tests\Unit\Endpoints;
+namespace Alma\API\Tests\Unit\PHP7_2\Endpoints;
 
 use Mockery;
 use PHPUnit\Framework\TestCase;
@@ -248,7 +248,7 @@ class PaymentsTest extends TestCase
      * Return input to test testFullRefund
      * @return array[]
      */
-    public function getFullRefundData()
+    public static function getFullRefundData()
     {
         return [
             [[
@@ -504,7 +504,7 @@ class PaymentsTest extends TestCase
         $payments->fullRefund($id);
     }
 
-    public function tearDown()
+    public function tearDown() : void
     {
         Mockery::close();
     }

--- a/tests/Unit/PHP7_2/RequestErrorTest.php
+++ b/tests/Unit/PHP7_2/RequestErrorTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Alma\API\Tests\Unit\PHP7_2;
+
+use PHPUnit\Framework\TestCase;
+use Alma\API\Response;
+use Alma\API\RequestError;
+use Mockery;
+use Psr\Log\NullLogger;
+
+/**
+ * Class RequestErrorTest
+ */
+class RequestErrorTest extends TestCase
+{
+
+    /**
+     * Return faulty options to test ClientOptionsValidator::validateOptions
+     * @return array
+     */
+    public function getErrorMessageProvider()
+    {
+        $validExpected = 'some error message';
+        $validResponse = Mockery::mock(Response::class);
+        $validResponse->errorMessage = $validExpected;
+
+        $noMessageExpected = 'error message hidden in response';
+        $noMessageResponse = Mockery::mock(Response::class);
+        $noMessageResponse->errorMessage = null;
+        $noMessageResponse->json = [
+            'errors' => [
+                0 => [
+                    'message' => $noMessageExpected
+                ]
+            ]
+        ];
+
+        return [
+            'valid example' => [
+                null, $validResponse, $validExpected,
+            ],
+            'error message hidden in response' => [
+                null, $noMessageResponse, $noMessageExpected,
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider getErrorMessageProvider
+     * @return void
+     * @throws ParamsError
+     */
+    public function testGetErrorMessage($req, $res, $expected)
+    {
+        $requestError = new RequestError($res->errorMessage, $req, $res);
+
+        $this->assertEquals($expected, $requestError->getErrorMessage());
+    }
+}

--- a/tests/Unit/PHP8_1/ArrayUtilsTest.php
+++ b/tests/Unit/PHP8_1/ArrayUtilsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Alma\API\Tests\Unit\PHP8_1;
+
+use Alma\API\Lib\ArrayUtils;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class ArrayUtils
+ */
+class ArrayUtilsTest extends TestCase
+{
+    /**
+     * Return options to test ArrayUtils::isAssocArray
+     * @return array[]
+     */
+    public static function getTestArrays()
+    {
+        return [
+            [['a', 'b', 'c'], false],
+            [["0" => 'a', "1" => 'b', "2" => 'c'], false],
+            [["1" => 'a', "0" => 'b', "2" => 'c'], false],
+            [["a" => 'a', "b" => 'b', "c" => 'c'], true],
+        ];
+    }
+
+    /**
+     * @dataProvider getTestArrays
+     * @return void
+     */
+    public function testIsAssocArray($testArray, $expectedResult)
+    {
+        $result = ArrayUtils::isAssocArray($testArray);
+        $this->assertEquals($expectedResult, $result);
+    }
+}

--- a/tests/Unit/PHP8_1/ClientContextTest.php
+++ b/tests/Unit/PHP8_1/ClientContextTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Alma\API\Tests\Unit\PHP8_1;
+
+use Alma\API\ClientContext;
+use PHPUnit\Framework\TestCase;
+use Alma\API\Client;
+use Psr\Log\NullLogger;
+
+/**
+ * Class ClientContextTest
+ */
+class ClientContextTest extends TestCase
+{
+    /** @var string  */
+    const FAKE_API_URI = 'https://fake-api.getalma.eu';
+
+    /**
+     * Return faulty options to test ClientOptionsValidator::validateOptions
+     * @return array
+     */
+    public static function getClientconfigOptions()
+    {
+        return [
+            'empty' => [[
+                'api_root' => [
+                    Client::TEST_MODE => self::FAKE_API_URI,
+                    Client::LIVE_MODE => self::FAKE_API_URI
+                ],
+                'force_tls' => 0,
+                'mode' => Client::TEST_MODE,
+                'logger' => new NullLogger()
+            ]],
+            'user_agent_component' => [[
+                'api_root' => [
+                    Client::TEST_MODE => self::FAKE_API_URI,
+                    Client::LIVE_MODE => self::FAKE_API_URI
+                ],
+                'force_tls' => 0,
+                'mode' => Client::TEST_MODE,
+                'logger' => new NullLogger(),
+                'user_agent_component' => ['Magento' => '12.3']
+            ]],
+        ];
+    }
+
+    /**
+     * @dataProvider getClientconfigOptions
+     * @return void
+     * @throws ParamsError
+     */
+    public function testClientContext($options)
+    {
+        $context = new ClientContext("sk_fake_api_key", $options);
+
+        $this->assertInstanceOf(ClientContext::class, $context);
+    }
+}

--- a/tests/Unit/PHP8_1/ClientOptionsValidatorTest.php
+++ b/tests/Unit/PHP8_1/ClientOptionsValidatorTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Alma\API\Tests\Unit\PHP8_1;
+
+use Alma\API\Lib\ClientOptionsValidator;
+use Alma\API\Client;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Alma\API\ParamsError;
+
+/**
+ * Class ClientOptionsValidatorTest
+ */
+class ClientOptionsValidatorTest extends TestCase
+{
+    /** @var string  */
+    const FAKE_API_URI = 'https://fake-api.getalma.eu';
+
+    /**
+     * Return options to test ClientOptionsValidator::validateOptions
+     * @return array
+     */
+    public static function getClientOptions()
+    {
+        return [
+            [
+                [],
+                [
+                    'api_root' => [
+                        Client::TEST_MODE => Client::SANDBOX_API_URL,
+                        Client::LIVE_MODE => Client::LIVE_API_URL
+                    ],
+                    'force_tls' => 2,
+                    'mode' => Client::LIVE_MODE,
+                    'logger' => new NullLogger()
+                ]
+            ],
+            [
+                [
+                    'api_root' => [
+                        Client::TEST_MODE => self::FAKE_API_URI,
+                        Client::LIVE_MODE => self::FAKE_API_URI
+                    ],
+                    'force_tls' => 0,
+                    'mode' => Client::TEST_MODE,
+                    'logger' => new NullLogger()
+                ],
+                [
+                    'api_root' => [
+                        Client::TEST_MODE => self::FAKE_API_URI,
+                        Client::LIVE_MODE => self::FAKE_API_URI
+                    ],
+                    'force_tls' => 0,
+                    'mode' => Client::TEST_MODE,
+                    'logger' => new NullLogger()
+                ]
+            ],
+            [
+                [
+                    'api_root' => self::FAKE_API_URI,
+                    'force_tls' => true,
+                    'logger' => new NullLogger()
+                ],
+                [
+                    'api_root' => [
+                        Client::TEST_MODE => self::FAKE_API_URI,
+                        Client::LIVE_MODE => self::FAKE_API_URI
+                    ],
+                    'force_tls' => 2,
+                    'mode' => Client::LIVE_MODE,
+                    'logger' => new NullLogger()
+                ]
+            ],
+            [
+                [
+                    'user_agent_component' => [
+                        'PrestaShop' => 2.3,
+                        'Alma for PrestaShop' => 'v2.3',
+                    ]
+                ],
+                [
+                    'api_root' => [
+                        Client::TEST_MODE => Client::SANDBOX_API_URL,
+                        Client::LIVE_MODE => Client::LIVE_API_URL
+                    ],
+                    'force_tls' => 2,
+                    'mode' => Client::LIVE_MODE,
+                    'logger' => new NullLogger(),
+                    'user_agent_component' => [
+                        'PrestaShop' => 2.3,
+                        'Alma for PrestaShop' => 'v2.3',
+                    ]
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider getClientOptions
+     * @return void
+     * @throws ParamsError
+     */
+    public function testClientOptionsValidator($options, $expectedResult)
+    {
+        $validatedConfig = ClientOptionsValidator::validateOptions($options);
+
+        $this->assertEquals($expectedResult, $validatedConfig);
+    }
+
+    /**
+     * Return faulty options to test ClientOptionsValidator::validateOptions
+     * @return array
+     */
+    public static function getInvalidClientOptions()
+    {
+        return [
+            'invalid api_root' => [
+                [
+                    'api_root' => [
+                        'something wrong' => Client::SANDBOX_API_URL,
+                        'something wronger' => Client::LIVE_API_URL
+                    ],
+                ],
+            ],
+            'invalid tls' => [
+                [
+                    'force_tls' => -1,
+                ],
+            ],
+            'invalid mode' => [
+                [
+                    'mode' => 'sad',
+                ],
+            ],
+            'invalid user_agent_component' => [
+                [
+                    'user_agent_component' => [
+                        'I dont give a key:value pair',
+                    ]
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider getInvalidClientOptions
+     * @return void
+     * @throws ParamsError
+     */
+    public function testFaultyClientOptionsValidator($options)
+    {
+        $this->expectException(ParamsError::class);
+        ClientOptionsValidator::validateOptions($options);
+    }
+}

--- a/tests/Unit/PHP8_1/Endpoints/PaymentsTest.php
+++ b/tests/Unit/PHP8_1/Endpoints/PaymentsTest.php
@@ -1,0 +1,511 @@
+<?php
+
+namespace Alma\API\Tests\Unit\PHP8_1\Endpoints;
+
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+use Alma\API\Endpoints\Payments;
+use Alma\API\Lib\ClientOptionsValidator;
+use Alma\API\ClientContext;
+use Alma\API\Request;
+use Alma\API\ParamsError;
+use Alma\API\RequestError;
+
+/**
+ * Class Payments
+ */
+class PaymentsTest extends TestCase
+{
+    const MERCHANT_REF = "merchant_ref";
+
+    /**
+     * Ensure that the methods exists
+     */
+    public function testRefundMethodExist()
+    {
+        $clientContext = Mockery::mock(ClientContext::class);
+
+        $payments = new Payments($clientContext);
+
+        $this->assertEquals(true, method_exists($payments, 'partialRefund'));
+        $this->assertEquals(true, method_exists($payments, 'fullRefund'));
+        # ensure backward compatibility
+        $this->assertEquals(true, method_exists($payments, 'refund'));
+    }
+
+    /**
+     * Mock ClientContext, Response and Request to allow us to test
+     * Payment without sending any requests
+     */
+    private function mockServerRequest()
+    {
+        // ClientContext
+        $clientContext = Mockery::mock(ClientContext::class);
+        $clientContext->shouldReceive('urlFor');
+        $clientContext->shouldReceive('getUserAgentString');
+        $clientContext->shouldReceive('forcedTLSVersion');
+
+        // Response
+        $json = '{
+           "payment_plan":[
+              {
+                 "customer_can_postpone":false,
+                 "customer_fee":100,
+                 "customer_interest":0,
+                 "date_paid":1649672472,
+                 "due_date":1649672451,
+                 "id":"installment_11uPRjPgPJ5jxmEEXxIPPOvVA3Fh7cg13m",
+                 "original_purchase_amount":11733,
+                 "purchase_amount":11733,
+                 "state":"paid"
+              },
+              {
+                 "customer_can_postpone":false,
+                 "customer_fee":0,
+                 "customer_interest":0,
+                 "date_paid":null,
+                 "due_date":1652264451,
+                 "id":"installment_11uPRjP4a3cFQvoM1lehDnpxa2tYm2Hy0I",
+                 "original_purchase_amount":11733,
+                 "purchase_amount":0,
+                 "state":"paid"
+              },
+              {
+                 "customer_can_postpone":false,
+                 "customer_fee":0,
+                 "customer_interest":0,
+                 "date_paid":null,
+                 "due_date":1654942851,
+                 "id":"installment_11uPRjP79fG5QtHO54lSYsnDvyHb56oeCn",
+                 "original_purchase_amount":11733,
+                 "purchase_amount":0,
+                 "state":"paid"
+              }
+           ],
+           "orders":[
+              {
+                 "comment":null,
+                 "created":1649672451,
+                 "customer_url":null,
+                 "data":{},
+                 "id":"order_11uPRjP4L9Dgbttx3cFUKGFPppdZIlrR2V",
+                 "merchant_reference":"00000206",
+                 "merchant_url":null,
+                 "payment":"payment_11uPRjP5FaIYygQao8WdMQFnKRMOV14frx"
+              }
+           ],
+           "refunds":[
+              {
+                 "amount":35299,
+                 "created":1649770695,
+                 "from_payment_cancellation":false,
+                 "id":"refund_11uPrHz4TfHmQrD1OkYyWb4hPuq3673Vqm",
+                 "merchant_reference":null,
+                 "payment":"payment_11uPRjP5FaIYygQao8WdMQFnKRMOV14frx",
+                 "payment_refund_amount":11833,
+                 "rebate_amount":23466
+              }
+           ]
+        }';
+
+        $responseMock = Mockery::mock(Response::class);
+        $responseMock->shouldReceive('isError')->andReturn(false);
+        $responseMock->json = json_decode($json, true);
+
+        // Request
+        $requestMock = Mockery::mock(Request::class);
+        $requestMock->shouldReceive('setRequestBody');
+        $requestMock->shouldReceive('post')->andReturn($responseMock);
+        return $requestMock;
+    }
+
+    /**
+     * Return input to test testPartialRefund
+     * @return array[]
+     */
+    public static function getPartialRefundData()
+    {
+        return [
+            [[
+                'id' => "some_id",
+                'amount' => 15000,
+                'merchant_ref' => self::MERCHANT_REF,
+                'comment' => "some comment"
+            ]],
+            [[
+                'id' => "some_id",
+                'amount' => 15000,
+                'merchant_ref' => self::MERCHANT_REF
+            ]],
+            [[
+                'id' => "some_id",
+                'amount' => 15000
+            ]]
+        ];
+    }
+
+    private function callPartialRefund($payments, $data)
+    {
+        if (isset($data['merchant_ref']) && isset($data['comment'])) {
+            $payments->partialRefund($data['id'], $data['amount'], $data['merchant_ref'], $data['comment']);
+        } elseif (isset($data['merchant_ref'])) {
+            $payments->partialRefund($data['id'], $data['amount'], $data['merchant_ref']);
+        } elseif (isset($data['comment'])) {
+            $payments->partialRefund($data['id'], $data['amount'], '', $data['comment']);
+        } else {
+            $payments->partialRefund($data['id'], $data['amount']);
+        }
+    }
+
+    /**
+     * Test the partialRefund method with valid datas
+     * @dataProvider getPartialRefundData
+     * @return void
+     */
+    public function testPartialRefund($data)
+    {
+        $clientContext = Mockery::mock(ClientContext::class);
+
+        // Payment
+        $payments = Mockery::mock(Payments::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial()
+        ;
+        $id = $data['id'];
+        $payments->shouldReceive('request')
+            ->with("/v1/payments/$id/refund")
+            ->once()
+            ->andReturn($this->mockServerRequest())
+        ;
+        $payments->setClientContext($clientContext);
+
+        /* Test */
+        $this->callPartialRefund($payments, $data);
+    }
+
+    /**
+     * Return invalid input to test testPartialRefund
+     * @return array[]
+     */
+    public static function getPartialRefundInvalidData()
+    {
+        return [
+            [[
+                'id' => "negative_amount",
+                'amount' => -1
+            ], ParamsError::class],
+            [[
+                'id' => "",
+                'amount' => 1500,
+                'merchant_ref' => "no id",
+            ], ParamsError::class],
+        ];
+    }
+
+    /**
+     * Test the partialRefund method with valid datas
+     * @dataProvider getPartialRefundInvalidData
+     * @return void
+     */
+    public function testInvalidPartialRefund($data, $expectedException)
+    {
+        $clientContext = Mockery::mock(ClientContext::class);
+
+        // Payment
+        $payments = Mockery::mock(Payments::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial()
+        ;
+        $id = $data['id'];
+        $payments->shouldReceive('request')
+            ->with("/v1/payments/$id/refund")
+            ->andReturn($this->mockServerRequest())
+        ;
+        $payments->setClientContext($clientContext);
+
+        $this->expectException($expectedException);
+
+        /* Test */
+        $this->callPartialRefund($payments, $data);
+    }
+
+
+    private function callFullRefund($payments, $data)
+    {
+        if (isset($data['merchant_ref']) && isset($data['comment'])) {
+            $payments->fullRefund($data['id'], $data['merchant_ref'], $data['comment']);
+        } elseif (isset($data['merchant_ref'])) {
+            $payments->fullRefund($data['id'], $data['merchant_ref']);
+        } elseif (isset($data['comment'])) {
+            $payments->fullRefund($data['id'], '', $data['comment']);
+        } else {
+            $payments->fullRefund($data['id']);
+        }
+    }
+
+    /**
+     * Return input to test testFullRefund
+     * @return array[]
+     */
+    public static function getFullRefundData()
+    {
+        return [
+            [[
+                'id' => "some_id",
+                'merchant_ref' => self::MERCHANT_REF,
+                'comment' => "some comment"
+            ]],
+            [[
+                'id' => "some_id",
+                'merchant_ref' => self::MERCHANT_REF
+            ]],
+            [[
+                'id' => "some_id",
+            ]]
+        ];
+    }
+
+    /**
+     * Test the fullRefund method with valid datas
+     * @dataProvider getFullRefundData
+     * @return void
+     */
+    public function testFullRefund($data)
+    {
+        $clientContext = Mockery::mock(ClientContext::class);
+
+        // Payment
+        $payments = Mockery::mock(Payments::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial()
+        ;
+        $id = $data['id'];
+        $payments->shouldReceive('request')
+            ->with("/v1/payments/$id/refund")
+            ->once()
+            ->andReturn($this->mockServerRequest())
+        ;
+        $payments->setClientContext($clientContext);
+
+        /* Test */
+        $this->callFullRefund($payments, $data);
+    }
+
+    /**
+     * Return input to test testRefund
+     * @return array[]
+     */
+    public static function getRefundData()
+    {
+        return [
+            [[
+                'id' => "some_id",
+                'amount' => 15000,
+                'merchant_ref' => self::MERCHANT_REF,
+            ]],
+            [[
+                'id' => "some_id",
+            ]],
+            [[
+                'id' => "some_id",
+                'amount' => 15000
+            ]]
+        ];
+    }
+
+    private function callRefund($payments, $data)
+    {
+        if (isset($data['merchant_ref']) && isset($data['amount'])) {
+            $payments->refund($data['id'], $data['amount'], $data['merchant_ref']);
+        } elseif (isset($data['amount'])) {
+            $payments->refund($data['id'], $data['amount']);
+        } else {
+            $payments->refund($data['id']);
+        }
+    }
+
+    /**
+     * Test the fullRefund method with valid datas
+     * Important to ensure we didn't break compatibility with 1.x.x versions
+     * @dataProvider getRefundData
+     * @return void
+     */
+    public function testRefund($data)
+    {
+        $clientContext = Mockery::mock(ClientContext::class);
+
+        // Payment
+        $payments = Mockery::mock(Payments::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial()
+        ;
+        $id = $data['id'];
+        $payments->shouldReceive('request')
+            ->with("/v1/payments/$id/refund")
+            ->once()
+            ->andReturn($this->mockServerRequest())
+        ;
+        $payments->setClientContext($clientContext);
+
+        /* Test */
+        $this->callRefund($payments, $data);
+    }
+
+    /**
+     * Return invalid input to test testFullRefund
+     * @return array[]
+     */
+    public static function getFullRefundInvalidData()
+    {
+        return [
+            [[
+                'id' => "",
+                'merchant_ref' => "no id",
+            ], ParamsError::class],
+        ];
+    }
+
+    /**
+     * Test the fullRefund method with valid datas
+     * @dataProvider getFullRefundInvalidData
+     * @return void
+     */
+    public function testInvalidFullRefund($data, $expectedException)
+    {
+        $clientContext = Mockery::mock(ClientContext::class);
+
+        // Payment
+        $payments = Mockery::mock(Payments::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial()
+        ;
+        $id = $data['id'];
+        $payments->shouldReceive('request')
+            ->with("/v1/payments/$id/refund")
+            ->andReturn($this->mockServerRequest())
+        ;
+        $payments->setClientContext($clientContext);
+
+        $this->expectException($expectedException);
+
+        /* Test */
+        $this->callFullRefund($payments, $data);
+    }
+
+    /**
+     * Mock ClientContext, Response and Request to allow us to test
+     * Payment without sending any requests but returns an error
+     */
+    private function mockServerRequestError()
+    {
+        // ClientContext
+        $clientContext = Mockery::mock(ClientContext::class);
+        $clientContext->shouldReceive('urlFor');
+        $clientContext->shouldReceive('getUserAgentString');
+        $clientContext->shouldReceive('forcedTLSVersion');
+
+        // Response
+        $json = '{
+           "payment_plan":[
+              {
+                 "customer_can_postpone":false,
+                 "customer_fee":100,
+                 "customer_interest":0,
+                 "date_paid":1649672472,
+                 "due_date":1649672451,
+                 "id":"installment_11uPRjPgPJ5jxmEEXxIPPOvVA3Fh7cg13m",
+                 "original_purchase_amount":11733,
+                 "purchase_amount":11733,
+                 "state":"paid"
+              },
+              {
+                 "customer_can_postpone":false,
+                 "customer_fee":0,
+                 "customer_interest":0,
+                 "date_paid":null,
+                 "due_date":1652264451,
+                 "id":"installment_11uPRjP4a3cFQvoM1lehDnpxa2tYm2Hy0I",
+                 "original_purchase_amount":11733,
+                 "purchase_amount":0,
+                 "state":"paid"
+              },
+              {
+                 "customer_can_postpone":false,
+                 "customer_fee":0,
+                 "customer_interest":0,
+                 "date_paid":null,
+                 "due_date":1654942851,
+                 "id":"installment_11uPRjP79fG5QtHO54lSYsnDvyHb56oeCn",
+                 "original_purchase_amount":11733,
+                 "purchase_amount":0,
+                 "state":"paid"
+              }
+           ],
+           "orders":[
+              {
+                 "comment":null,
+                 "created":1649672451,
+                 "customer_url":null,
+                 "data":{},
+                 "id":"order_11uPRjP4L9Dgbttx3cFUKGFPppdZIlrR2V",
+                 "merchant_reference":"00000206",
+                 "merchant_url":null,
+                 "payment":"payment_11uPRjP5FaIYygQao8WdMQFnKRMOV14frx"
+              }
+           ],
+           "refunds":[
+              {
+                 "amount":35299,
+                 "created":1649770695,
+                 "from_payment_cancellation":false,
+                 "id":"refund_11uPrHz4TfHmQrD1OkYyWb4hPuq3673Vqm",
+                 "merchant_reference":null,
+                 "payment":"payment_11uPRjP5FaIYygQao8WdMQFnKRMOV14frx",
+                 "payment_refund_amount":11833,
+                 "rebate_amount":23466
+              }
+           ]
+        }';
+
+        $responseMock = Mockery::mock(Response::class);
+        $responseMock->shouldReceive('isError')->andReturn(true);
+        $responseMock->json = json_decode($json, true);
+        $responseMock->errorMessage = "a very important error message";
+
+        // Request
+        $requestMock = Mockery::mock(Request::class);
+        $requestMock->shouldReceive('setRequestBody');
+        $requestMock->shouldReceive('post')->andReturn($responseMock);
+        return $requestMock;
+    }
+
+    public function testFullRefundRequestError()
+    {
+        // Input
+        $clientContext = Mockery::mock(ClientContext::class);
+        $id = "some_id";
+
+        // Payment
+        $payments = Mockery::mock(Payments::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial()
+        ;
+        $payments->shouldReceive('request')
+            ->with("/v1/payments/$id/refund")
+            ->once()
+            ->andReturn($this->mockServerRequestError())
+        ;
+        $payments->setClientContext($clientContext);
+
+        $this->expectException(RequestError::class);
+
+        /* Test */
+        $payments->fullRefund($id);
+    }
+
+    public function tearDown() : void
+    {
+        Mockery::close();
+    }
+}

--- a/tests/Unit/PHP8_1/RequestErrorTest.php
+++ b/tests/Unit/PHP8_1/RequestErrorTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Alma\API\Tests\Unit\PHP8_1;
+
+use PHPUnit\Framework\TestCase;
+use Alma\API\Response;
+use Alma\API\RequestError;
+use Mockery;
+use Psr\Log\NullLogger;
+
+/**
+ * Class RequestErrorTest
+ */
+class RequestErrorTest extends TestCase
+{
+
+    /**
+     * Return faulty options to test ClientOptionsValidator::validateOptions
+     * @return array
+     */
+    public static function getErrorMessageProvider()
+    {
+        $validExpected = 'some error message';
+        $validResponse = Mockery::mock(Response::class);
+        $validResponse->errorMessage = $validExpected;
+
+        $noMessageExpected = 'error message hidden in response';
+        $noMessageResponse = Mockery::mock(Response::class);
+        $noMessageResponse->errorMessage = null;
+        $noMessageResponse->json = [
+            'errors' => [
+                0 => [
+                    'message' => $noMessageExpected
+                ]
+            ]
+        ];
+
+        return [
+            'valid example' => [
+                null, $validResponse, $validExpected,
+            ],
+            'error message hidden in response' => [
+                null, $noMessageResponse, $noMessageExpected,
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider getErrorMessageProvider
+     * @return void
+     * @throws ParamsError
+     */
+    public function testGetErrorMessage($req, $res, $expected)
+    {
+        $requestError = new RequestError((string) $res->errorMessage, $req, $res);
+
+        $this->assertEquals($expected, $requestError->getErrorMessage());
+    }
+}


### PR DESCRIPTION
### Reason for change

[Add the Psr2 and 3 compatibility](https://linear.app/almapay/issue/MPP-510/php-client-psrlog-compatibility)
[Fix the tests for all PHP versions](https://linear.app/almapay/issue/MPP-536/fix-unit-test-php-client)

### How to test

- Follow the test process describe in the readme of the test folder
- Try to log with different version of PHP and component
