### PR TITLE
Insurance data tracking - Add header in insurance calls

### DIFF
--- a/src/Endpoints/Insurance.php
+++ b/src/Endpoints/Insurance.php
@@ -40,7 +40,13 @@ class Insurance extends Base
      * @throws RequestError
      * @throws RequestException
      */
-    public function getInsuranceContract($insuranceContractExternalId, $cmsReference, $productPrice, $customerSessionId = null, $cartId = null)
+    public function getInsuranceContract(
+        $insuranceContractExternalId,
+        $cmsReference,
+        $productPrice,
+        $customerSessionId = null,
+        $cartId = null
+    )
     {
         if (is_int($cmsReference)) {
             $cmsReference = (string)$cmsReference;
@@ -48,10 +54,12 @@ class Insurance extends Base
 
         $this->checkParameters($cmsReference, $insuranceContractExternalId, $productPrice);
 
-        $request = $this->request(sprintf(
+        $request = $this->request(
+            sprintf(
                 "%sinsurance-contracts/%s",
                 self::INSURANCE_PATH,
-                $insuranceContractExternalId)
+                $insuranceContractExternalId
+            )
         )->setQueryParams([
             'cms_reference' => $cmsReference,
             'product_price' => $productPrice

--- a/src/Endpoints/Insurance.php
+++ b/src/Endpoints/Insurance.php
@@ -33,14 +33,14 @@ class Insurance extends Base
      * @param string $cmsReference
      * @param int|string $productPrice
      * @param string | null $customerSessionId
-     * @param string | null $customerSessionExpirationTime
+     * @param string | null $cartId
      * @return Contract|null
      * @throws MissingKeyException
      * @throws ParametersException
      * @throws RequestError
      * @throws RequestException
      */
-    public function getInsuranceContract($insuranceContractExternalId, $cmsReference, $productPrice, $customerSessionId = null, $customerSessionExpirationTime = null)
+    public function getInsuranceContract($insuranceContractExternalId, $cmsReference, $productPrice, $customerSessionId = null, $cartId = null)
     {
         if (is_int($cmsReference)) {
             $cmsReference = (string)$cmsReference;
@@ -58,7 +58,7 @@ class Insurance extends Base
         ]);
 
 
-        $this->addCustomerSessionToRequest($request, $customerSessionId, $customerSessionExpirationTime);
+        $this->addCustomerSessionToRequest($request, $customerSessionId, $cartId);
 
         $response = $request->get();
 
@@ -96,13 +96,13 @@ class Insurance extends Base
      * @param $subscriptionArray
      * @param null $paymentId
      * @param string | null $customerSessionId
-     * @param string | null $customerSessionExpirationTime
+     * @param string | null $cartId
      * @return mixed
      * @throws ParametersException
      * @throws RequestError
      * @throws RequestException
      */
-    public function subscription($subscriptionArray, $paymentId = null, $customerSessionId = null, $customerSessionExpirationTime = null)
+    public function subscription($subscriptionArray, $paymentId = null, $customerSessionId = null, $cartId = null)
     {
 
         if (!is_array($subscriptionArray)) {
@@ -118,7 +118,7 @@ class Insurance extends Base
         $request = $this->request(self::INSURANCE_PATH . 'subscriptions')
             ->setRequestBody($subscriptionData);
 
-        $this->addCustomerSessionToRequest($request, $customerSessionId, $customerSessionExpirationTime);
+        $this->addCustomerSessionToRequest($request, $customerSessionId, $cartId);
 
         $response = $request->post();
 
@@ -229,17 +229,17 @@ class Insurance extends Base
     /**
      * @param \Alma\API\Request $request
      * @param string | null $customerSessionId
-     * @param string | null $customerSessionExpirationTime
+     * @param string | null $cartId
      * @return void
      */
-    public function addCustomerSessionToRequest($request, $customerSessionId, $customerSessionExpirationTime)
+    public function addCustomerSessionToRequest($request, $customerSessionId = null, $cartId = null)
     {
         if ($customerSessionId) {
             $request->addCustomerSessionIdToHeader($customerSessionId);
         }
 
-        if ($customerSessionExpirationTime) {
-            $request->addCustomerSessionExpirationTimeToHeader($customerSessionExpirationTime);
+        if ($cartId) {
+            $request->addCartIdToHeader($cartId);
         }
     }
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -77,7 +77,7 @@ class Request
 	}
 	public function addCustomerSessionExpirationTimeToHeader($customerSessionExpirationTime)
 	{
-		$this->headers[] = 'X-Customer-Session-Expiration-Time: ' . $customerSessionExpirationTime;
+		$this->headers[] = 'X-Customer-Session-Duration-Time: ' . $customerSessionExpirationTime;
 	}
 
     private function initCurl()

--- a/src/Request.php
+++ b/src/Request.php
@@ -71,6 +71,15 @@ class Request
         $this->initCurl();
     }
 
+	public function addCustomerSessionIdToHeader($customerSession)
+	{
+		$this->headers[] = 'X-Customer-Session-Id: ' . $customerSession;
+	}
+	public function addCustomerSessionExpirationTimeToHeader($customerSessionExpirationTime)
+	{
+		$this->headers[] = 'X-Customer-Session-Expiration-Time: ' . $customerSessionExpirationTime;
+	}
+
     private function initCurl()
     {
         $this->curlHandle = curl_init();

--- a/src/Request.php
+++ b/src/Request.php
@@ -71,13 +71,22 @@ class Request
         $this->initCurl();
     }
 
-	public function addCustomerSessionIdToHeader($customerSession)
+    /**
+     * @param string $customerSessionId
+     * @return void
+     */
+    public function addCustomerSessionIdToHeader($customerSessionId)
 	{
-		$this->headers[] = 'X-Customer-Session-Id: ' . $customerSession;
+		$this->headers[] = 'X-Customer-Session-Id: ' . $customerSessionId;
 	}
-	public function addCustomerSessionExpirationTimeToHeader($customerSessionExpirationTime)
+
+    /**
+     * @param string $cartId
+     * @return void
+     */
+    public function addCartIdToHeader($cartId)
 	{
-		$this->headers[] = 'X-Customer-Session-Duration-Time: ' . $customerSessionExpirationTime;
+		$this->headers[] = 'X-Customer-Cart-Id: ' . $cartId;
 	}
 
     private function initCurl()


### PR DESCRIPTION
### Reason for change
Add X-Customer-Session-Id and X-Customer-Cart-Id in insurance calls
<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1197/php-client)

### Code changes
Add nullable params in insurance eligibility and subscription.
<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

Log headers before send an insurance request.

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [x] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [x] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [x] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->