### PR TITLE
Don't remove amount if value equal zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+v2.0.1
+-------
+* Fix : Don't remove amount in refund if value equal zero
+
 v2.0.0
 -------
 * Added Alma insurance endpoints

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "alma/alma-php-client",
   "description": "PHP API client for the Alma payments API",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "library",
   "require": {
     "php": "^5.6 || ~7.0 || ~7.1 || ~7.2 || ~7.3 || ~7.4 || ~8.0 || ~8.1 || ~8.2",

--- a/src/Client.php
+++ b/src/Client.php
@@ -30,7 +30,7 @@ use Alma\API\Lib\ClientOptionsValidator;
 
 class Client
 {
-    const VERSION = '2.0.0';
+    const VERSION = '2.0.1';
 
     const LIVE_MODE = 'live';
     const TEST_MODE = 'test';

--- a/src/Endpoints/Payments.php
+++ b/src/Endpoints/Payments.php
@@ -26,6 +26,8 @@
 namespace Alma\API\Endpoints;
 
 use Alma\API\Endpoints\Results\Eligibility;
+use Alma\API\Exceptions\ParametersException;
+use Alma\API\Exceptions\RequestException;
 use Alma\API\Lib\PaymentValidator;
 use Alma\API\ParamsError;
 use Alma\API\Payloads\Refund;
@@ -219,7 +221,9 @@ class Payments extends Base
      * @param string $comment
      *
      * @return Payment
+     * @throws ParametersException
      * @throws RequestError
+     * @throws RequestException
      */
     public function partialRefund($id, $amount, $merchantReference = "", $comment = "") {
         return $this->doRefund(
@@ -234,7 +238,9 @@ class Payments extends Base
      * @param string $comment
      *
      * @return Payment
+     * @throws ParametersException
      * @throws RequestError
+     * @throws RequestException
      */
     public function fullRefund($id, $merchantReference = "", $comment = "") {
         return $this->doRefund(
@@ -248,6 +254,8 @@ class Payments extends Base
      *
      * @return Payment
      * @throws RequestError
+     * @throws RequestException
+     * @throws ParametersException
      */
     private function doRefund(Refund $refundPayload) {
         $id = $refundPayload->getId();
@@ -257,7 +265,7 @@ class Payments extends Base
 
         $res = $req->post();
         if ($res->isError()) {
-            throw new RequestError($res->errorMessage, $req, $res);
+            throw new RequestException($res->errorMessage, $req, $res);
         }
 
         return new Payment($res->json);
@@ -272,8 +280,9 @@ class Payments extends Base
      * @param string $merchantReference Merchant reference for the refund to be executed
      *
      * @return Payment
+     * @throws ParametersException
      * @throws RequestError
-     *
+     * @throws RequestException
      * @deprecated please use `partialRefund` or `fullRefund`
      */
     public function refund($id, $totalRefund = true, $amount = null, $merchantReference = "") {

--- a/src/Endpoints/Payments.php
+++ b/src/Endpoints/Payments.php
@@ -244,7 +244,7 @@ class Payments extends Base
      */
     public function fullRefund($id, $merchantReference = "", $comment = "") {
         return $this->doRefund(
-            Refund::create($id, 0, $merchantReference, $comment)
+            Refund::create($id, null, $merchantReference, $comment)
         );
     }
 

--- a/src/Payloads/Refund.php
+++ b/src/Payloads/Refund.php
@@ -25,7 +25,7 @@
 
 namespace Alma\API\Payloads;
 
-use Alma\API\ParamsError;
+use Alma\API\Exceptions\ParametersException;
 
 class Refund
 {
@@ -48,18 +48,18 @@ class Refund
      * @param int $amount the amount to refund, 0 means all
      * @param string $merchantReference a reference for the merchant
      * @param string $comment
-     * @return Alma\API\Refund
+     * @return Refund
      *
-     * @throws ParamsError
+     * @throws ParametersException
      */
     public static function create($id, $amount = 0, $merchantReference = "", $comment = "")
     {
         if ($id === '') {
-            throw new ParamsError('Refund Error. Payment Id can\'t be empty.');
+            throw new ParametersException('Refund Error. Payment Id can\'t be empty.');
         }
 
         if ($amount < 0) {
-            throw new ParamsError('Refund Error. You can\'t refund a negative amount.');
+            throw new ParametersException('Refund Error. You can\'t refund a negative amount.');
         }
 
         $refundPayload = new self($id);
@@ -68,6 +68,7 @@ class Refund
         }
         $refundPayload->setMerchantReference($merchantReference);
         $refundPayload->setComment($comment);
+
         return $refundPayload;
     }
 
@@ -136,15 +137,17 @@ class Refund
 
     /**
      * @return array
+     * @throws ParametersException
      */
     public function getRequestBody() {
-        $requestBody = [
+        if ($this->getAmount() === 0) {
+            throw new ParametersException('Refund warning, the refund is zero');
+        }
+
+        return [
+            "amount" => $this->getAmount(),
             "merchant_reference" => $this->getMerchantReference(),
             "comment" => $this->getComment(),
         ];
-        if ($this->getAmount() > 0) {
-            $requestBody["amount"] = $this->getAmount();
-        }
-        return $requestBody;
     }
 }

--- a/src/Payloads/Refund.php
+++ b/src/Payloads/Refund.php
@@ -152,7 +152,7 @@ class Refund
         if (
             $this->getAmount() !== null &&
             $this->getAmount() > 0
-        ){
+        ) {
             $requestBody["amount"] = $this->getAmount();
         }
 

--- a/src/Payloads/Refund.php
+++ b/src/Payloads/Refund.php
@@ -32,7 +32,7 @@ class Refund
     /* @param string */
     private $id;
 
-    /* @param int */
+    /* @param int|null */
     private $amount = 0;
 
     /* @param string */
@@ -144,10 +144,18 @@ class Refund
             throw new ParametersException('Refund warning, the refund is zero');
         }
 
-        return [
-            "amount" => $this->getAmount(),
+        $requestBody = [
             "merchant_reference" => $this->getMerchantReference(),
             "comment" => $this->getComment(),
         ];
+
+        if (
+            $this->getAmount() !== null &&
+            $this->getAmount() > 0
+        ){
+            $requestBody["amount"] = $this->getAmount();
+        }
+
+        return $requestBody;
     }
 }


### PR DESCRIPTION
### Reason for change

[ClickUp task](https://linear.app/almapay/issue/ECOM-1261/%5Bphp-client%5D-dont-remove-amount-if-value-equal-zero)

### Code changes

We don't make full refund anymore if amount equal zero, but only if we send null. We send an error if amount equals zero.

### How to test

Make a partial refund or a full refund from an order.

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->