### PR TITLE
Fix/ecom 1327/add amount to subscription object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 v2.0.2
 -------
 * Added getSubscription endpoint Insurance
+* Fix Subscription amount model
 
 v2.0.1
 -------

--- a/src/Endpoints/Insurance.php
+++ b/src/Endpoints/Insurance.php
@@ -182,6 +182,7 @@ class Insurance extends Base
 
             $subscriptionData['subscriptions'][] = [
                 'insurance_contract_id' => $subscription->getContractId(),
+                'amount' => $subscription->getAmount(),
                 'cms_reference' => $subscription->getCmsReference(),
                 'product_price' => $subscription->getProductPrice(),
                 'cms_callback_url' => $subscription->getCallbackUrl(),

--- a/src/Entities/Insurance/Subscription.php
+++ b/src/Entities/Insurance/Subscription.php
@@ -9,6 +9,10 @@ class Subscription
      */
     private $contractId;
     /**
+     * @var int
+     */
+    private $amount;
+    /**
      * @var string
      */
     private $cmsReference;
@@ -33,6 +37,7 @@ class Subscription
 
     /**
      * @param string $contractId
+     * @param int  $amount
      * @param string $cmsReference
      * @param int $productPrice
      * @param Subscriber $subscriber
@@ -40,6 +45,7 @@ class Subscription
      */
     public function __construct(
         $contractId,
+        $amount,
         $cmsReference,
         $productPrice,
         $subscriber,
@@ -47,6 +53,7 @@ class Subscription
     )
     {
         $this->contractId = $contractId;
+        $this->amount = $amount;
         $this->cmsReference = $cmsReference;
         $this->productPrice = $productPrice;
         $this->subscriber = $subscriber;
@@ -57,6 +64,7 @@ class Subscription
     {
         return [
             $this->contractId,
+            $this->amount,
             $this->cmsReference,
             $this->productPrice,
             $this->subscriber,
@@ -102,5 +110,13 @@ class Subscription
     public function getSubscriber()
     {
         return $this->subscriber;
+    }
+
+    /**
+     * @return int
+     */
+    public function getAmount()
+    {
+        return $this->amount;
     }
 }

--- a/src/Entities/Insurance/Subscription.php
+++ b/src/Entities/Insurance/Subscription.php
@@ -63,12 +63,12 @@ class Subscription
     public function getAll()
     {
         return [
-            $this->contractId,
-            $this->amount,
-            $this->cmsReference,
-            $this->productPrice,
-            $this->subscriber,
-            $this->callbackUrl,
+            $this->getContractId(),
+            $this->getAmount(),
+            $this->getCmsReference(),
+            $this->getProductPrice(),
+            $this->getSubscriber(),
+            $this->getCallbackUrl(),
         ];
     }
 

--- a/tests/Unit/Legacy/Endpoints/InsuranceTest.php
+++ b/tests/Unit/Legacy/Endpoints/InsuranceTest.php
@@ -63,6 +63,7 @@ class InsuranceTest extends TestCase
                 [
                     new Subscription(
                         'insurance_contract_6VU1zZ5AKfy6EejiNxmLXh',
+                        1235,
                         '19',
                         1312,
                         new Subscriber(
@@ -81,6 +82,7 @@ class InsuranceTest extends TestCase
                     ),
                     new Subscription(
                         'insurance_contract_3vt2jyvWWQc9wZCmWd1KtI',
+                        1568,
                         '17-35',
                         1312,
                         new Subscriber(
@@ -104,6 +106,7 @@ class InsuranceTest extends TestCase
                 [
                     new Subscription(
                         'insurance_contract_6VU1zZ5AKfy6EejiNxmLXh',
+                        1235,
                         '19',
                         1312,
                         new Subscriber(
@@ -122,6 +125,7 @@ class InsuranceTest extends TestCase
                     ),
                     new Subscription(
                         'insurance_contract_3vt2jyvWWQc9wZCmWd1KtI',
+                        1568,
                         '17-35',
                         1312,
                         new Subscriber(

--- a/tests/Unit/Legacy/Entities/Insurance/SubscriptionTest.php
+++ b/tests/Unit/Legacy/Entities/Insurance/SubscriptionTest.php
@@ -36,6 +36,7 @@ class  SubscriptionTest extends TestCase
 
         return new Subscription(
             $data['insurance_contract_id'],
+            $data['amount'],
             $data['cms_reference'],
             $data['product_price'],
             $this->getSubscriber(),
@@ -50,6 +51,7 @@ class  SubscriptionTest extends TestCase
     {
         return [
             'insurance_contract_id' => 'insurance_contract_id_123456789',
+            'amount' => 1235,
             'cms_reference' => '14-35',
             'product_price' => 10012
         ];


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Liinear task](https://linear.app/almapay/issue/ECOM-1327/[adobecommerce]-update-amount-sent-to-subscription)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
Add amount in Subscription model

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->