### PR TITLE
Add order id in subscription model and call to api

### DIFF
--- a/src/Endpoints/Insurance.php
+++ b/src/Endpoints/Insurance.php
@@ -169,7 +169,7 @@ class Insurance extends Base
     protected function buildSubscriptionData($subscriptionArray, $orderId ,$paymentId = null)
     {
         $subscriptionData = ['subscriptions' => []];
-        $subscriptionData['orderId'] = $orderId;
+        $subscriptionData['order_id'] = $orderId;
 
         /**
          * @var Subscription $subscription
@@ -212,7 +212,6 @@ class Insurance extends Base
         ) {
             $subscriptionData['payment_id'] = $paymentId;
         }
-
         return $subscriptionData;
     }
 

--- a/src/Endpoints/Insurance.php
+++ b/src/Endpoints/Insurance.php
@@ -102,6 +102,7 @@ class Insurance extends Base
 
     /**
      * @param $subscriptionArray
+     * @param string $orderId
      * @param null $paymentId
      * @param string | null $customerSessionId
      * @param string | null $cartId
@@ -110,7 +111,7 @@ class Insurance extends Base
      * @throws RequestError
      * @throws RequestException
      */
-    public function subscription($subscriptionArray, $paymentId = null, $customerSessionId = null, $cartId = null)
+    public function subscription($subscriptionArray, $orderId, $paymentId = null, $customerSessionId = null, $cartId = null)
     {
 
         if (!is_array($subscriptionArray)) {
@@ -122,7 +123,7 @@ class Insurance extends Base
             );
         }
 
-        $subscriptionData = $this->buildSubscriptionData($subscriptionArray, $paymentId);
+        $subscriptionData = $this->buildSubscriptionData($subscriptionArray, $orderId, $paymentId);
         $request = $this->request(self::INSURANCE_PATH . 'subscriptions')
             ->setRequestBody($subscriptionData);
 
@@ -145,7 +146,7 @@ class Insurance extends Base
     public function getSubscription($subscriptionIds)
     {
         $this->insuranceValidator->checkSubscriptionIds($subscriptionIds);
-        $response = $this->request(
+          $response = $this->request(
             self::INSURANCE_PATH . 'subscriptions'
         )->setQueryParams(
             $subscriptionIds
@@ -160,13 +161,15 @@ class Insurance extends Base
 
     /**
      * @param array $subscriptionArray
+     * @param string $orderId
      * @param string|null $paymentId
      * @return array
      * @throws ParametersException
      */
-    protected function buildSubscriptionData($subscriptionArray, $paymentId = null)
+    protected function buildSubscriptionData($subscriptionArray, $orderId ,$paymentId = null)
     {
         $subscriptionData = ['subscriptions' => []];
+        $subscriptionData['orderId'] = $orderId;
 
         /**
          * @var Subscription $subscription

--- a/src/Endpoints/Insurance.php
+++ b/src/Endpoints/Insurance.php
@@ -111,7 +111,13 @@ class Insurance extends Base
      * @throws RequestError
      * @throws RequestException
      */
-    public function subscription($subscriptionArray, $orderId, $paymentId = null, $customerSessionId = null, $cartId = null)
+    public function subscription(
+        $subscriptionArray,
+        $orderId,
+        $paymentId = null,
+        $customerSessionId = null,
+        $cartId = null
+    )
     {
 
         if (!is_array($subscriptionArray)) {
@@ -166,7 +172,7 @@ class Insurance extends Base
      * @return array
      * @throws ParametersException
      */
-    protected function buildSubscriptionData($subscriptionArray, $orderId ,$paymentId = null)
+    protected function buildSubscriptionData($subscriptionArray, $orderId, $paymentId = null)
     {
         $subscriptionData = ['subscriptions' => []];
         $subscriptionData['order_id'] = $orderId;

--- a/tests/Unit/Legacy/Endpoints/InsuranceTest.php
+++ b/tests/Unit/Legacy/Endpoints/InsuranceTest.php
@@ -548,7 +548,7 @@ class InsuranceTest extends TestCase
     {
         $insurance = new Insurance($this->clientContext);
         $this->expectException(ParametersException::class);
-        $insurance->subscription($nonArrayParam, $nonStringPaymentId);
+        $insurance->subscription($nonArrayParam,'orderID', $nonStringPaymentId);
     }
 
     /**
@@ -575,7 +575,7 @@ class InsuranceTest extends TestCase
             ->andReturn($requestObject);
         $insurance->setClientContext($this->clientContext);
         $this->expectException(RequestException::class);
-        $insurance->subscription($subscriptionArray);
+        $insurance->subscription($subscriptionArray,'orderId');
     }
 
     /**
@@ -588,8 +588,15 @@ class InsuranceTest extends TestCase
      */
     public function testSubscriptionGetRequestCall($subscriptionArray, $paymentId)
     {
+        $setRequestPayload =   [
+            'subscriptions' => $subscriptionArray,
+            'orderId' => 'myOrderId'
+        ];
+        if($paymentId){
+            $setRequestPayload['paymentId'] = $paymentId;
+        }
         $this->responseMock->shouldReceive('isError')->once()->andReturn(false);
-        $this->requestObject->shouldReceive('setRequestBody')->andReturn($this->requestObject);
+        $this->requestObject->shouldReceive('setRequestBody')->once()->with($setRequestPayload)->andReturn($this->requestObject);
         $this->requestObject->shouldReceive('post')->once()->andReturn($this->responseMock);
 
         $insurance = Mockery::mock(Insurance::class)->shouldAllowMockingProtectedMethods()->makePartial();
@@ -598,7 +605,7 @@ class InsuranceTest extends TestCase
             ->once()
             ->andReturn($this->requestObject);
         $insurance->setClientContext($this->clientContext);
-        $insurance->subscription($subscriptionArray, $paymentId);
+        $insurance->subscription($subscriptionArray, 'myOrderId' ,$paymentId);
     }
 
     /**

--- a/tests/Unit/Legacy/Endpoints/InsuranceTest.php
+++ b/tests/Unit/Legacy/Endpoints/InsuranceTest.php
@@ -23,6 +23,10 @@ class InsuranceTest extends TestCase
 {
     const INSURANCE_SUBSCRIPTIONS_PATH = '/v1/insurance/subscriptions';
     const INSURANCE_CONTRACTS_PATH = '/v1/insurance/insurance-contracts/';
+    const TEST_PHONENUMBER = '+33601010101';
+    const TEST_EMAIL = 'test@almapay.com';
+    const TEST_CMSREFERENCE = '17-35';
+    const TEST_BIRTHDATE = '1988-08-22';
     /**
 	 * @var ClientContext
 	 */
@@ -67,8 +71,8 @@ class InsuranceTest extends TestCase
                         '19',
                         1312,
                         new Subscriber(
-                            'test@almapay.com',
-                            '+33601010101',
+                            self::TEST_EMAIL,
+                            self::TEST_PHONENUMBER,
                             'lastname',
                             'firstname',
                             'address1',
@@ -83,11 +87,11 @@ class InsuranceTest extends TestCase
                     new Subscription(
                         'insurance_contract_3vt2jyvWWQc9wZCmWd1KtI',
                         1568,
-                        '17-35',
+                        self::TEST_CMSREFERENCE,
                         1312,
                         new Subscriber(
-                            'test@almapay.com',
-                            '+33601010101',
+                            self::TEST_EMAIL,
+                            self::TEST_PHONENUMBER,
                             'last',
                             'first',
                             'adr1',
@@ -95,7 +99,7 @@ class InsuranceTest extends TestCase
                             'zip',
                             'city',
                             'country',
-                            '1988-08-22'
+                            self::TEST_BIRTHDATE
                         ),
                         'cancelUrl'
                     )
@@ -110,8 +114,8 @@ class InsuranceTest extends TestCase
                             'product_price' => 1312,
                             'cms_callback_url' => 'cancelUrl',
                             'subscriber' => [
-                                'email' => 'test@almapay.com',
-                                'phone_number' => '+33601010101',
+                                'email' => self::TEST_EMAIL,
+                                'phone_number' => self::TEST_PHONENUMBER,
                                 'last_name' => 'lastname',
                                 'first_name' => 'firstname',
                                 'birthdate' => null,
@@ -127,15 +131,15 @@ class InsuranceTest extends TestCase
                         [
                             'insurance_contract_id' => 'insurance_contract_3vt2jyvWWQc9wZCmWd1KtI',
                             'amount' => 1568,
-                            'cms_reference' => '17-35',
+                            'cms_reference' => self::TEST_CMSREFERENCE,
                             'product_price' => 1312,
                             'cms_callback_url' => 'cancelUrl',
                             'subscriber' => [
-                                'email' => 'test@almapay.com',
-                                'phone_number' => '+33601010101',
+                                'email' => self::TEST_EMAIL,
+                                'phone_number' => self::TEST_PHONENUMBER,
                                 'last_name' => 'last',
                                 'first_name' => 'first',
-                                'birthdate' => '1988-08-22',
+                                'birthdate' => self::TEST_BIRTHDATE,
                                 'address' => [
                                     'address_line_1' => 'adr1',
                                     'address_line_2' => 'adr2',
@@ -156,8 +160,8 @@ class InsuranceTest extends TestCase
                         '19',
                         1312,
                         new Subscriber(
-                            'test@almapay.com',
-                            '+33601010101',
+                            self::TEST_EMAIL,
+                            self::TEST_PHONENUMBER,
                             'lastname',
                             'firstname',
                             'address1',
@@ -172,11 +176,11 @@ class InsuranceTest extends TestCase
                     new Subscription(
                         'insurance_contract_3vt2jyvWWQc9wZCmWd1KtI',
                         1568,
-                        '17-35',
+                        self::TEST_CMSREFERENCE,
                         1312,
                         new Subscriber(
-                            'test@almapay.com',
-                            '+33601010101',
+                            self::TEST_EMAIL,
+                            self::TEST_PHONENUMBER,
                             'last',
                             'first',
                             'adr1',
@@ -184,7 +188,7 @@ class InsuranceTest extends TestCase
                             'zip',
                             'city',
                             'country',
-                            '1988-08-22'
+                            self::TEST_BIRTHDATE
                         ),
                         'cancelUrl'
                     )
@@ -199,8 +203,8 @@ class InsuranceTest extends TestCase
                             'product_price' => 1312,
                             'cms_callback_url' => 'cancelUrl',
                             'subscriber' => [
-                                'email' => 'test@almapay.com',
-                                'phone_number' => '+33601010101',
+                                'email' => self::TEST_EMAIL,
+                                'phone_number' => self::TEST_PHONENUMBER,
                                 'last_name' => 'lastname',
                                 'first_name' => 'firstname',
                                 'birthdate' => null,
@@ -216,15 +220,15 @@ class InsuranceTest extends TestCase
                         [
                             'insurance_contract_id' => 'insurance_contract_3vt2jyvWWQc9wZCmWd1KtI',
                             'amount' => 1568,
-                            'cms_reference' => '17-35',
+                            'cms_reference' => self::TEST_CMSREFERENCE,
                             'product_price' => 1312,
                             'cms_callback_url' => 'cancelUrl',
                             'subscriber' => [
-                                'email' => 'test@almapay.com',
-                                'phone_number' => '+33601010101',
+                                'email' => self::TEST_EMAIL,
+                                'phone_number' => self::TEST_PHONENUMBER,
                                 'last_name' => 'last',
                                 'first_name' => 'first',
-                                'birthdate' => '1988-08-22',
+                                'birthdate' => self::TEST_BIRTHDATE,
                                 'address' => [
                                     'address_line_1' => 'adr1',
                                     'address_line_2' => 'adr2',
@@ -640,7 +644,7 @@ class InsuranceTest extends TestCase
     {
         $insurance = new Insurance($this->clientContext);
         $this->expectException(ParametersException::class);
-        $insurance->subscription($nonArrayParam,'orderID', $nonStringPaymentId);
+        $insurance->subscription($nonArrayParam, 'orderID', $nonStringPaymentId);
     }
 
     /**
@@ -667,7 +671,7 @@ class InsuranceTest extends TestCase
             ->andReturn($requestObject);
         $insurance->setClientContext($this->clientContext);
         $this->expectException(RequestException::class);
-        $insurance->subscription($subscriptionArray,'orderId');
+        $insurance->subscription($subscriptionArray, 'orderId');
     }
 
     /**
@@ -698,7 +702,7 @@ class InsuranceTest extends TestCase
             ->once()
             ->andReturn($this->requestObject);
         $insurance->setClientContext($this->clientContext);
-        $insurance->subscription($subscriptionArray, 'myOrderId' ,$paymentId);
+        $insurance->subscription($subscriptionArray, 'myOrderId', $paymentId);
     }
 
     /**

--- a/tests/Unit/Legacy/Endpoints/InsuranceTest.php
+++ b/tests/Unit/Legacy/Endpoints/InsuranceTest.php
@@ -67,15 +67,15 @@ class InsuranceTest extends TestCase
                         '19',
                         1312,
                         new Subscriber(
-                            'mathis.dupuy@almapay.com',
-                            '+33622484646',
-                            'sub1',
-                            'sub1',
-                            'adr1',
-                            'adr1',
-                            'adr1',
-                            'adr1',
-                            'adr1',
+                            'test@almapay.com',
+                            '+33601010101',
+                            'lastname',
+                            'firstname',
+                            'address1',
+                            'address2',
+                            'zipcode',
+                            'city',
+                            'country',
                             null
                         ),
                         'cancelUrl'
@@ -86,21 +86,67 @@ class InsuranceTest extends TestCase
                         '17-35',
                         1312,
                         new Subscriber(
-                            'mathis.dupuy@almapay.com',
-                            '+33622484646',
-                            'sub2',
-                            'sub2',
+                            'test@almapay.com',
+                            '+33601010101',
+                            'last',
+                            'first',
+                            'adr1',
                             'adr2',
-                            'adr2',
-                            'adr2',
-                            'adr2',
-                            'adr2',
+                            'zip',
+                            'city',
+                            'country',
                             '1988-08-22'
                         ),
                         'cancelUrl'
                     )
                 ],
-                null
+                null,
+                [
+                    'subscriptions' => [
+                        [
+                            'insurance_contract_id' => 'insurance_contract_6VU1zZ5AKfy6EejiNxmLXh',
+                            'amount' => 1235,
+                            'cms_reference' => '19',
+                            'product_price' => 1312,
+                            'cms_callback_url' => 'cancelUrl',
+                            'subscriber' => [
+                                'email' => 'test@almapay.com',
+                                'phone_number' => '+33601010101',
+                                'last_name' => 'lastname',
+                                'first_name' => 'firstname',
+                                'birthdate' => null,
+                                'address' => [
+                                    'address_line_1' => 'address1',
+                                    'address_line_2' => 'address2',
+                                    'zip_code' => 'zipcode',
+                                    'city' => 'city',
+                                    'country' => 'country',
+                                ]
+                            ],
+                        ],
+                        [
+                            'insurance_contract_id' => 'insurance_contract_3vt2jyvWWQc9wZCmWd1KtI',
+                            'amount' => 1568,
+                            'cms_reference' => '17-35',
+                            'product_price' => 1312,
+                            'cms_callback_url' => 'cancelUrl',
+                            'subscriber' => [
+                                'email' => 'test@almapay.com',
+                                'phone_number' => '+33601010101',
+                                'last_name' => 'last',
+                                'first_name' => 'first',
+                                'birthdate' => '1988-08-22',
+                                'address' => [
+                                    'address_line_1' => 'adr1',
+                                    'address_line_2' => 'adr2',
+                                    'zip_code' => 'zip',
+                                    'city' => 'city',
+                                    'country' => 'country',
+                                ]
+                            ],
+                        ]
+                    ]
+                ]
             ],
             'Test with right data and payment id' => [
                 [
@@ -110,15 +156,15 @@ class InsuranceTest extends TestCase
                         '19',
                         1312,
                         new Subscriber(
-                            'mathis.dupuy@almapay.com',
-                            '+33622484646',
-                            'sub1',
-                            'sub1',
-                            'adr1',
-                            'adr1',
-                            'adr1',
-                            'adr1',
-                            'adr1',
+                            'test@almapay.com',
+                            '+33601010101',
+                            'lastname',
+                            'firstname',
+                            'address1',
+                            'address2',
+                            'zipcode',
+                            'city',
+                            'country',
                             null
                         ),
                         'cancelUrl'
@@ -129,21 +175,67 @@ class InsuranceTest extends TestCase
                         '17-35',
                         1312,
                         new Subscriber(
-                            'mathis.dupuy@almapay.com',
-                            '+33622484646',
-                            'sub2',
-                            'sub2',
+                            'test@almapay.com',
+                            '+33601010101',
+                            'last',
+                            'first',
+                            'adr1',
                             'adr2',
-                            'adr2',
-                            'adr2',
-                            'adr2',
-                            'adr2',
+                            'zip',
+                            'city',
+                            'country',
                             '1988-08-22'
                         ),
                         'cancelUrl'
                     )
                 ],
-                'payment_id' => 'payment_11xlpX9QQYhd3xZVzNMrtdKw4myV7QET7X'
+                'payment_id' => 'payment_11xlpX9QQYhd3xZVzNMrtdKw4myV7QET7X',
+                [
+                    'subscriptions' => [
+                        [
+                            'insurance_contract_id' => 'insurance_contract_6VU1zZ5AKfy6EejiNxmLXh',
+                            'amount' => 1235,
+                            'cms_reference' => '19',
+                            'product_price' => 1312,
+                            'cms_callback_url' => 'cancelUrl',
+                            'subscriber' => [
+                                'email' => 'test@almapay.com',
+                                'phone_number' => '+33601010101',
+                                'last_name' => 'lastname',
+                                'first_name' => 'firstname',
+                                'birthdate' => null,
+                                'address' => [
+                                    'address_line_1' => 'address1',
+                                    'address_line_2' => 'address2',
+                                    'zip_code' => 'zipcode',
+                                    'city' => 'city',
+                                    'country' => 'country',
+                                ]
+                            ],
+                        ],
+                        [
+                            'insurance_contract_id' => 'insurance_contract_3vt2jyvWWQc9wZCmWd1KtI',
+                            'amount' => 1568,
+                            'cms_reference' => '17-35',
+                            'product_price' => 1312,
+                            'cms_callback_url' => 'cancelUrl',
+                            'subscriber' => [
+                                'email' => 'test@almapay.com',
+                                'phone_number' => '+33601010101',
+                                'last_name' => 'last',
+                                'first_name' => 'first',
+                                'birthdate' => '1988-08-22',
+                                'address' => [
+                                    'address_line_1' => 'adr1',
+                                    'address_line_2' => 'adr2',
+                                    'zip_code' => 'zip',
+                                    'city' => 'city',
+                                    'country' => 'country',
+                                ]
+                            ],
+                        ]
+                    ]
+                ]
             ]
         ];
     }
@@ -582,21 +674,22 @@ class InsuranceTest extends TestCase
      * @dataProvider subscriptionDataProvider
      * @param $subscriptionArray
      * @param $paymentId
+     * @param $expectedSubscriptionPayload
      * @throws ParametersException
      * @throws RequestError
      * @throws RequestException
      */
-    public function testSubscriptionGetRequestCall($subscriptionArray, $paymentId)
+    public function testSubscriptionGetRequestCall($subscriptionArray, $paymentId, $expectedSubscriptionPayload)
     {
-        $setRequestPayload =   [
-            'subscriptions' => $subscriptionArray,
-            'orderId' => 'myOrderId'
-        ];
-        if($paymentId){
-            $setRequestPayload['paymentId'] = $paymentId;
+        $expectedSubscriptionPayload['order_id'] = 'myOrderId';
+
+        if ($paymentId) {
+            $expectedSubscriptionPayload['payment_id'] = $paymentId;
         }
         $this->responseMock->shouldReceive('isError')->once()->andReturn(false);
-        $this->requestObject->shouldReceive('setRequestBody')->once()->with($setRequestPayload)->andReturn($this->requestObject);
+        $this->requestObject->shouldReceive('setRequestBody')->once()
+            ->with($expectedSubscriptionPayload)
+            ->andReturn($this->requestObject);
         $this->requestObject->shouldReceive('post')->once()->andReturn($this->responseMock);
 
         $insurance = Mockery::mock(Insurance::class)->shouldAllowMockingProtectedMethods()->makePartial();


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[ClickUp task](https://linear.app/almapay/issue/ECOM-1347/add-order-id-in-subscription-call-to-api)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->