### PR TITLE
Add throw if return 0 data on getSubscription

### DIFF
--- a/src/Endpoints/Insurance.php
+++ b/src/Endpoints/Insurance.php
@@ -8,6 +8,7 @@ use Alma\API\Entities\Insurance\Subscription;
 use Alma\API\Exceptions\MissingKeyException;
 use Alma\API\Exceptions\ParametersException;
 use Alma\API\Exceptions\RequestException;
+use Alma\API\Exceptions\ResponseException;
 use Alma\API\Lib\ArrayUtils;
 use Alma\API\Lib\InsuranceValidator;
 use Alma\API\RequestError;
@@ -137,10 +138,11 @@ class Insurance extends Base
     }
 
     /**
-     * @throws RequestError
+     * @return array json_decode in response constructor
      * @throws RequestException
      * @throws ParametersException
-     * @return array json_decode in response constructor
+     * @throws ResponseException
+     * @throws RequestError
      */
     public function getSubscription($subscriptionIds)
     {
@@ -153,6 +155,11 @@ class Insurance extends Base
 
         if ($response->isError()) {
             throw new RequestException($response->errorMessage, null, $response);
+        }
+
+        $subscriptions = json_decode($response->json, true)['subscriptions'];
+        if (!count($subscriptions)) {
+            throw new ResponseException('No data was found', 404);
         }
 
         return $response->json;


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[ClickUp task](https://linear.app/almapay/issue/ECOM-1351/[php-client]-add-throw-if-return-0-data-on-getsubscription)

### Code changes

Add throw Response Exception if return 0 data on getSubscription

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->