### PR TITLE
Feature/ecom 1356 php client add statutspending cancellation

### DIFF
--- a/src/Entities/Insurance/Subscription.php
+++ b/src/Entities/Insurance/Subscription.php
@@ -30,11 +30,11 @@ class Subscription
      */
     private $callbackUrl;
 
-    CONST STATE_STARTED = 'started';
-    CONST STATE_FAILED = 'failed';
-    CONST STATE_CANCELLED = 'canceled';
-    CONST STATE_PENDING = 'pending';
-    CONST STATE_PENDING_CANCELLATION = 'pending_cancellation';
+    const STATE_STARTED = 'started';
+    const STATE_FAILED = 'failed';
+    const STATE_CANCELLED = 'canceled';
+    const STATE_PENDING = 'pending';
+    const STATE_PENDING_CANCELLATION = 'pending_cancellation';
 
     /**
      * @param string $contractId

--- a/src/Entities/Insurance/Subscription.php
+++ b/src/Entities/Insurance/Subscription.php
@@ -34,6 +34,7 @@ class Subscription
     CONST STATE_FAILED = 'failed';
     CONST STATE_CANCELLED = 'canceled';
     CONST STATE_PENDING = 'pending';
+    CONST STATE_PENDING_CANCELLATION = 'pending_cancellation';
 
     /**
      * @param string $contractId


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->
Add new state in subscription model : pending_cancellation.
Pending state is now used for the return of subscription API.
[Linear task](https://linear.app/almapay/issue/ECOM-1356/[php-client]-add-statutspending-cancellation)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->