### PR TITLE
Fix php client get subscription details

### DIFF
--- a/src/Endpoints/Insurance.php
+++ b/src/Endpoints/Insurance.php
@@ -163,8 +163,7 @@ class Insurance extends Base
         if ($response->isError()) {
             throw new RequestException($response->errorMessage, null, $response);
         }
-
-        $subscriptions = json_decode($response->json, true)['subscriptions'];
+        $subscriptions = $response->json['subscriptions'];
         if (!count($subscriptions)) {
             throw new ResponseException('No data was found', 404);
         }

--- a/src/Endpoints/Insurance.php
+++ b/src/Endpoints/Insurance.php
@@ -150,6 +150,7 @@ class Insurance extends Base
      * @throws ParametersException
      * @throws RequestError
      * @throws RequestException
+     * @throws ResponseException
      */
     public function getSubscription($subscriptionIds)
     {

--- a/tests/Unit/Legacy/Endpoints/InsuranceTest.php
+++ b/tests/Unit/Legacy/Endpoints/InsuranceTest.php
@@ -750,7 +750,7 @@ class InsuranceTest extends TestCase
      */
     public function testGetSubscriptionRequestIsCalled($subscriptionIds, $json)
     {
-        $this->responseMock->json = $json;
+        $this->responseMock->json = json_decode($json,true);
         $this->responseMock->shouldReceive('isError')->once()->andReturn(false);
         $this->requestObject->shouldReceive('get')->once()->andReturn($this->responseMock);
         $this->requestObject->shouldReceive('setQueryParams')
@@ -822,7 +822,7 @@ class InsuranceTest extends TestCase
      */
     public function testGetSubscriptionsReturnApiResponse($subscriptionIds, $json)
     {
-        $this->responseMock->json = $json;
+        $this->responseMock->json = json_decode($json,true);
         $this->responseMock->shouldReceive('isError')->once()->andReturn(false);
         $this->requestObject->shouldReceive('get')->once()->andReturn($this->responseMock);
         $this->requestObject->shouldReceive('setQueryParams')->once()->andReturn($this->requestObject);
@@ -956,7 +956,7 @@ class InsuranceTest extends TestCase
      */
     public function testGetSubscriptionIfReturnZeroDataThrowException($subscriptionIdInvalid, $jsonReturnRequest)
     {
-        $this->responseMock->json = $jsonReturnRequest;
+        $this->responseMock->json = json_decode($jsonReturnRequest,true);
         $this->responseMock->shouldReceive('isError')->once()->andReturn(false);
         $this->requestObject->shouldReceive('setQueryParams')->once()->andReturn($this->requestObject);
         $this->requestObject->shouldReceive('get')->once()->andReturn($this->responseMock);

--- a/tests/Unit/Legacy/Endpoints/InsuranceTest.php
+++ b/tests/Unit/Legacy/Endpoints/InsuranceTest.php
@@ -750,7 +750,7 @@ class InsuranceTest extends TestCase
      */
     public function testGetSubscriptionRequestIsCalled($subscriptionIds, $json)
     {
-        $this->responseMock->json = json_decode($json,true);
+        $this->responseMock->json = json_decode($json, true);
         $this->responseMock->shouldReceive('isError')->once()->andReturn(false);
         $this->requestObject->shouldReceive('get')->once()->andReturn($this->responseMock);
         $this->requestObject->shouldReceive('setQueryParams')
@@ -821,7 +821,7 @@ class InsuranceTest extends TestCase
      */
     public function testGetSubscriptionsReturnApiResponse($subscriptionIds, $json)
     {
-        $this->responseMock->json = json_decode($json,true);
+        $this->responseMock->json = json_decode($json, true);
         $this->responseMock->shouldReceive('isError')->once()->andReturn(false);
         $this->requestObject->shouldReceive('get')->once()->andReturn($this->responseMock);
         $this->requestObject->shouldReceive('setQueryParams')->once()->andReturn($this->requestObject);
@@ -955,7 +955,7 @@ class InsuranceTest extends TestCase
      */
     public function testGetSubscriptionIfReturnZeroDataThrowException($subscriptionIdInvalid, $jsonReturnRequest)
     {
-        $this->responseMock->json = json_decode($jsonReturnRequest,true);
+        $this->responseMock->json = json_decode($jsonReturnRequest, true);
         $this->responseMock->shouldReceive('isError')->once()->andReturn(false);
         $this->requestObject->shouldReceive('setQueryParams')->once()->andReturn($this->requestObject);
         $this->requestObject->shouldReceive('get')->once()->andReturn($this->responseMock);

--- a/tests/Unit/Legacy/Endpoints/InsuranceTest.php
+++ b/tests/Unit/Legacy/Endpoints/InsuranceTest.php
@@ -818,7 +818,6 @@ class InsuranceTest extends TestCase
      * @throws ParametersException
      * @throws RequestError
      * @throws RequestException
-     * @throws ResponseException
      */
     public function testGetSubscriptionsReturnApiResponse($subscriptionIds, $json)
     {
@@ -832,7 +831,7 @@ class InsuranceTest extends TestCase
             ->andReturn($this->requestObject);
         $this->insuranceValidatorMock->shouldReceive('checkSubscriptionIds')->once();
 
-        $this->assertEquals($json, $this->insuranceMock->getSubscription($subscriptionIds));
+        $this->assertEquals($this->responseMock->json, $this->insuranceMock->getSubscription($subscriptionIds));
     }
 
     /**


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[ClickUp task](https://linear.app/almapay/issue/ECOM-1357/fix-php-client-get-subscription-details)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->