### PR TITLE
Fix throw exception on checkmandatorykeys without

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+v2.0.6
+-------
+* Fix error in throw exception without sprintf
+
 v2.0.5
 -------
 * Fix endpoint customer-carts

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "alma/alma-php-client",
   "description": "PHP API client for the Alma payments API",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "type": "library",
   "require": {
     "php": "^5.6 || ~7.0 || ~7.1 || ~7.2 || ~7.3 || ~7.4 || ~8.0 || ~8.1 || ~8.2",

--- a/src/Client.php
+++ b/src/Client.php
@@ -30,7 +30,7 @@ use Alma\API\Lib\ClientOptionsValidator;
 
 class Client
 {
-    const VERSION = '2.0.5';
+    const VERSION = '2.0.6';
 
     const LIVE_MODE = 'live';
     const TEST_MODE = 'test';

--- a/src/Lib/ArrayUtils.php
+++ b/src/Lib/ArrayUtils.php
@@ -55,7 +55,12 @@ class ArrayUtils
     {
         foreach ($keys as $key) {
             if(!array_key_exists($key, $array)){
-                throw new MissingKeyException('The key "%s" is missing from the array "%s"', $key, json_encode($array));
+                throw new MissingKeyException(
+                    sprintf(
+                        'The key "%s" is missing from the array "%s"',
+                        $key,
+                        json_encode($array)
+                ));
             }
         }
     }


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[ClickUp task](https://linear.app/almapay/issue/ECOM-1477/[php-client]-fix-throw-exception-on-checkmandatorykeys-without-sprintf)

### Code changes

add sprinf in throw exception
<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test
use the function checkMandatoryKeys in arrayUtils and throw exception
_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->