### PR TITLE
[DEX-889] Add a template for release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,21 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+template: |
+
+  $CHANGES
+
+change-template: '- $TITLE'
+change-title-escapes: '\<*_&#@`'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+      - 'type: feature'
+  patch:
+    labels:
+      - 'patch'
+  default: patch


### PR DESCRIPTION
### Reason for change


This is required to test https://github.com/alma/alma-php-client/pull/111 :
The template for release-drafter must exist in the default branch
See https://github.com/alma/alma-php-client/actions/runs/9468745618

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
This adds a really simple template for release-drafter