### PR TITLE
[DEVX] Fix release zip filename

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -81,8 +81,8 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ github.token }}" \
             -H "Content-Type: application/zip" \
-            -T "dist/alma.zip" \
-            https://uploads.github.com/repos/${{ github.repository }}/releases/${{ steps.fetch-release-draft.outputs.id }}/assets?name=alma.zip
+            -T "dist/alma-php-client.zip" \
+            https://uploads.github.com/repos/${{ github.repository }}/releases/${{ steps.fetch-release-draft.outputs.id }}/assets?name=alma-php-client.zip
 
       - name: Publish Github release
         uses: actions/github-script@v7


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding Linear task or Sentry issue. -->

`task dist` command results in the creation of the file `dist/alma-php-client.zip`
But in the release publish workflow, we are adding a file `dist/alma.zip` to the Github release. 
