### PR TITLE
[DEVX] Fix branch for release-drafter + don't publish internal changes in changelog

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,11 @@
+'type: chore': ['chore/*', 'renovate/*', 'chore(deps):*']
+'type: ci': ci/*
+'type: perf': perf/*
+'type: refator': refactor/*
+'type: test': test/*
+'type: docs': docs/*
+'type: bugfix': ['fix/*', 'bug/*', 'hotfix-backport/*']
+'type: feature': ['feature/*', 'feat/*']
+'type: security': ['security/*', 'dependabot/*']
+'type: hotfix': 'hotfix/*'
+'type: devx': 'devx/*'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,10 +2,33 @@ name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 
 template: |
+  ## Changes
 
   $CHANGES
 
-change-template: '- $TITLE'
+  ### Contributors
+
+  $CONTRIBUTORS
+
+categories:
+  - title: '🚀 New Features'
+    labels:
+      - 'type: feature'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'type: bugfix'
+      - 'type: hotfix'
+
+exclude-labels:
+  - 'skip-changelog'
+  - 'type: chore'
+  - 'type: ci'
+  - 'type: refactor'
+  - 'type: test'
+  - 'type: docs'
+  - 'type: security'
+  - 'type: devx'
+change-template: '- $TITLE (#$NUMBER)'
 change-title-escapes: '\<*_&#@`'
 version-resolver:
   major:

--- a/.github/workflows/backport-pull-request.yml
+++ b/.github/workflows/backport-pull-request.yml
@@ -34,3 +34,4 @@ jobs:
             title: Backport main to develop
             branch: chore/backport-main-to-develop
             base: develop
+            labels: skip-changelog

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,16 @@
+name: PR Labeler
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  pr-labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: TimonVS/pr-labeler-action@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -87,6 +87,8 @@ jobs:
       - name: Publish Github release
         uses: actions/github-script@v7
         with:
+          # target_commitish is set to refs/heads/develop by release-drafter as we need to retrieve pull requests merged into develop
+          # We need to override it to refs/heads/main to point to the last commit of main branch instead of develop branch
           script: |
             const { owner, repo } = context.repo;
             await github.rest.repos.updateRelease({
@@ -95,7 +97,8 @@ jobs:
               release_id: "${{ steps.fetch-release-draft.outputs.id }}",
               draft: false,
               make_latest: true,
-              tag_name: "${{ steps.fetch-release-draft.outputs.name }}"
+              tag_name: "${{ steps.fetch-release-draft.outputs.name }}",
+              target_commitish: "refs/heads/main
             });
 
       - name: Format release notes for Slack

--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -26,6 +26,11 @@ jobs:
       - name: Create release draft
         uses: release-drafter/release-drafter@v6
         id: release-drafter
+        with:
+          # release-drafter should be based on develop to get the correct content as pull requests are merged into develop
+          # Note that the target commitish of the release should be updated to refs/heads/main when published
+          # (Otherwise the tag will point to the last commit on develop branch instead of the last commit of main branch)
+          commitish: refs/heads/develop
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
### Reason for change
 
* Ensure release-drafter runs on develop branch to fetch the right changes
* Ensure that the release drafted points to a main commit when published
* Add pr-labeler workflow to add category labels on pull request
* Exclude pr with internal changes or with label `skip-changelog` from the changelog
