### PR TITLE
feature: refactor order and add updateTracking put endpoint

### DIFF
--- a/src/Endpoints/Orders.php
+++ b/src/Endpoints/Orders.php
@@ -65,6 +65,25 @@ class Orders extends Base
     }
 
     /**
+     * @param string $orderId
+     * @param string|null $carrier
+     * @param string|null $trackingNumber
+     * @param string|null $trackingUrl
+     * @return Order
+     * @throws AlmaException
+     */
+    public function updateTracking($orderId, $carrier = null, $trackingNumber = null, $trackingUrl = null)
+    {
+        $trackingData = array_filter([
+            'carrier' => $carrier,
+            'tracking_number' => $trackingNumber,
+            'tracking_url' => $trackingUrl
+        ]);
+        $response = $this->request(self::ORDERS_PATH . "/{$orderId}")->setRequestBody($trackingData)->put();
+        return new Order($response->json);
+    }
+
+    /**
      * @param int $limit
      * @param string|null $startingAfter
      * @param array $filters
@@ -91,7 +110,7 @@ class Orders extends Base
         $response = $this->request(self::ORDERS_PATH)->setQueryParams($args)->get();
         return new PaginatedResults(
             $response,
-            function($startingAfter) use ($limit, $filters) {
+            function ($startingAfter) use ($limit, $filters) {
                 return $this->fetchAll($limit, $startingAfter, $filters);
             }
         );
@@ -123,11 +142,11 @@ class Orders extends Base
 
         try {
             $response = $this->request(self::ORDERS_PATH_V2 . "/{$orderExternalId}/status")->setRequestBody(array(
-                'status' =>  $label,
+                'status' => $label,
                 'is_shipped' => $orderData['is_shipped'],
             ))->post();
-        }catch (AlmaException $e) {
-			$this->logger->error('Error sending status');
+        } catch (AlmaException $e) {
+            $this->logger->error('Error sending status');
             throw new RequestException('Error sending status', $e);
         }
 
@@ -143,21 +162,21 @@ class Orders extends Base
      */
     public function validateStatusData($orderData = array())
     {
-        if(count($orderData) == 0) {
+        if (count($orderData) == 0) {
             throw new ParametersException('Missing in the required parameters (status, is_shipped) when calling orders.sendStatus');
         }
 
         try {
             $this->arrayUtils->checkMandatoryKeys(['status', 'is_shipped'], $orderData);
-        } catch (MissingKeyException $e ) {
-            throw new ParametersException('Error in the required parameters (status, is_shipped) when calling orders.sendStatus',0,  $e);
+        } catch (MissingKeyException $e) {
+            throw new ParametersException('Error in the required parameters (status, is_shipped) when calling orders.sendStatus', 0, $e);
         }
 
-        if(!is_bool($orderData['is_shipped'])) {
+        if (!is_bool($orderData['is_shipped'])) {
             throw new ParametersException('Parameter "is_shipped" must be a boolean');
         }
 
-        if(!$orderData['status']) {
+        if (!$orderData['status']) {
             throw new ParametersException('Missing the required parameter "status" when calling orders.sendStatus');
         }
     }

--- a/src/Entities/Order.php
+++ b/src/Entities/Order.php
@@ -64,8 +64,14 @@ class Order
     /** @var string | null  URL to the merchant's backoffice for that Order */
     private $merchantUrl;
 
-    /** @var array  Free-form custom data */
+    /**
+     * @var array  Free-form custom data
+     * @deprecated
+     * */
     public $data;
+
+    /** @var array  Free-form custom data */
+    private $orderData;
 
     /**
      * @var string | null Order comment
@@ -104,6 +110,7 @@ class Order
         $this->createdAt = $orderDataArray['created'];
         $this->customerUrl = $orderDataArray['customer_url'];
         $this->data = $orderDataArray['data'];
+        $this->orderData = $orderDataArray['data'];
         $this->id = $orderDataArray['id'];
         $this->externalId = $orderDataArray['id'];
         $this->merchant_reference = $orderDataArray['merchant_reference'];
@@ -205,6 +212,14 @@ class Order
     public function getUpdatedAt()
     {
         return $this->updatedAt;
+    }
+
+    /**
+     * @return array
+     */
+    public function getOrderData()
+    {
+        return $this->orderData;
     }
 
 }

--- a/src/Entities/Order.php
+++ b/src/Entities/Order.php
@@ -121,10 +121,8 @@ class Order
         $this->paymentId = $orderDataArray['payment'];
         $this->trackingNumber = $orderDataArray['tracking_number'];
         $this->trackingUrl = $orderDataArray['tracking_url'];
-        $this->updatedAt = $orderDataArray['updated'];
+        $this->updatedAt = isset($orderDataArray['updated']) ? $orderDataArray['updated'] : null;
     }
-
-
 
     /**
      * @return string|null

--- a/src/Entities/Order.php
+++ b/src/Entities/Order.php
@@ -25,17 +25,186 @@
 
 namespace Alma\API\Entities;
 
-class Order extends Base
+class Order
 {
-    /** @var string ID of the Payment owning this Order */
+    /** @var string | null  Order carrier */
+    private $carrier;
+
+    /** @var string | null  Order carrier tracking number */
+    private $trackingNumber;
+
+    /** @var string | null  Order carrier tracking URL */
+    private $trackingUrl;
+
+    /** @var string ID of the Payment owning this Order
+     * @deprecated
+     */
     public $payment;
 
-    /** @var string Order reference from the merchant's platform */
+    /** @var string ID of the Payment owning this Order */
+    private $paymentId;
+
+    /**
+     * @var string | null  Order reference from the merchant's platform
+     * @deprecated
+     */
     public $merchant_reference;
 
-    /** @var string URL to the merchant's backoffice for that Order */
+    /**
+     * @var string | null  Order reference from the merchant's platform
+     */
+    private $merchantReference;
+
+    /**
+     * @var string | null  URL to the merchant's backoffice for that Order
+     * @deprecated
+     */
     public $merchant_url;
 
-    /** @var array Free-form custom data */
+    /** @var string | null  URL to the merchant's backoffice for that Order */
+    private $merchantUrl;
+
+    /** @var array  Free-form custom data */
     public $data;
+
+    /**
+     * @var string | null Order comment
+     */
+    private $comment;
+    /**
+     * @var int Order creation timestamp
+     */
+    private $createdAt;
+
+    /**
+     * @var string | null Customer URL
+     */
+    private $customerUrl;
+
+    /**
+     * @var string Order external ID
+     */
+    private $externalId;
+
+    /**
+     * @var string Order updated timestamp
+     */
+    private $updatedAt;
+    /**
+     * @var string Order ID
+     * @deprecated
+     */
+    public $id;
+
+
+    public function __construct($orderDataArray)
+    {
+        $this->carrier = $orderDataArray['carrier'];
+        $this->comment = $orderDataArray['comment'];
+        $this->createdAt = $orderDataArray['created'];
+        $this->customerUrl = $orderDataArray['customer_url'];
+        $this->data = $orderDataArray['data'];
+        $this->id = $orderDataArray['id'];
+        $this->externalId = $orderDataArray['id'];
+        $this->merchant_reference = $orderDataArray['merchant_reference'];
+        $this->merchantReference = $orderDataArray['merchant_reference'];
+        $this->merchant_url = $orderDataArray['merchant_url'];
+        $this->merchantUrl = $orderDataArray['merchant_url'];
+        $this->payment = $orderDataArray['payment'];
+        $this->paymentId = $orderDataArray['payment'];
+        $this->trackingNumber = $orderDataArray['tracking_number'];
+        $this->trackingUrl = $orderDataArray['tracking_url'];
+        $this->updatedAt = $orderDataArray['updated'];
+    }
+
+
+
+    /**
+     * @return string|null
+     */
+    public function getCarrier()
+    {
+        return $this->carrier;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getTrackingNumber()
+    {
+        return $this->trackingNumber;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getTrackingUrl()
+    {
+        return $this->trackingUrl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPaymentId()
+    {
+        return $this->paymentId;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getMerchantReference()
+    {
+        return $this->merchantReference;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getMerchantUrl()
+    {
+        return $this->merchantUrl;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExternalId()
+    {
+        return $this->externalId;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getComment()
+    {
+        return $this->comment;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCustomerUrl()
+    {
+        return $this->customerUrl;
+    }
+
+    /**
+     * @return int
+     */
+    public function getUpdatedAt()
+    {
+        return $this->updatedAt;
+    }
+
 }

--- a/tests/Integration/Endpoints/OrdersTest.php
+++ b/tests/Integration/Endpoints/OrdersTest.php
@@ -14,43 +14,43 @@ class OrdersTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
-        self::$almaClient = ClientTestHelper::getAlmaClient();
-        self::$payment = PaymentTestHelper::createPayment(26500, 3);
+        OrdersTest::$almaClient = ClientTestHelper::getAlmaClient();
+        OrdersTest::$payment = PaymentTestHelper::createPayment(26500, 3);
     }
 
     public function testCanCreateANewOrder()
     {
-        $payment = self::$payment;
+        $payment = OrdersTest::$payment;
         $order = $payment->orders[0];
         $this->assertInstanceOf(Order::class, $order);
         $this->assertEquals('ABC-123', $order->getMerchantReference());
-        $newOrder = self::$almaClient->payments->addOrder($payment->id, ['merchant_reference' => 'ABC-123-NEW']);
+        $newOrder = OrdersTest::$almaClient->payments->addOrder($payment->id, ['merchant_reference' => 'ABC-123-NEW']);
         $this->assertInstanceOf(Order::class, $newOrder);
         $this->assertEquals('ABC-123-NEW', $newOrder->getMerchantReference());
     }
 
     public function testCanUpdateOrderTracking()
     {
-        $payment = self::$payment;
+        $payment = OrdersTest::$payment;
         $order = $payment->orders[0];
         $this->assertInstanceOf(Order::class, $order);
         $this->assertNull($order->getCarrier());
         $this->assertNull($order->getTrackingUrl());
         $this->assertNull($order->getTrackingNumber());
 
-        $updatedOrder = self::$almaClient->orders->updateTracking($order->getExternalId(), null,null , 'https://tracking.com');
+        $updatedOrder = OrdersTest::$almaClient->orders->updateTracking($order->getExternalId(), null,null , 'https://tracking.com');
         $this->assertInstanceOf(Order::class, $updatedOrder);
         $this->assertNull($order->getCarrier());
         $this->assertNull($updatedOrder->getTrackingNumber());
         $this->assertEquals('https://tracking.com', $updatedOrder->getTrackingUrl());
 
-        $updatedOrder = self::$almaClient->orders->updateTracking($order->getExternalId(), 'UPS');
+        $updatedOrder = OrdersTest::$almaClient->orders->updateTracking($order->getExternalId(), 'UPS');
         $this->assertInstanceOf(Order::class, $updatedOrder);
         $this->assertEquals('UPS', $updatedOrder->getCarrier());
         $this->assertNull($updatedOrder->getTrackingNumber());
         $this->assertEquals('https://tracking.com', $updatedOrder->getTrackingUrl());
 
-        $updatedOrder = self::$almaClient->orders->updateTracking($order->getExternalId(), 'LAPOSTE','123456789' , 'https://laposte.com');
+        $updatedOrder = OrdersTest::$almaClient->orders->updateTracking($order->getExternalId(), 'LAPOSTE','123456789' , 'https://laposte.com');
         $this->assertInstanceOf(Order::class, $updatedOrder);
         $this->assertEquals('LAPOSTE', $updatedOrder->getCarrier());
         $this->assertEquals('123456789', $updatedOrder->getTrackingNumber());

--- a/tests/Integration/Endpoints/OrdersTest.php
+++ b/tests/Integration/Endpoints/OrdersTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Alma\API\Tests\Integration\Endpoints;
+
+use Alma\API\Entities\Order;
+use Alma\API\Tests\Integration\TestHelpers\ClientTestHelper;
+use Alma\API\Tests\Integration\TestHelpers\PaymentTestHelper;
+use PHPUnit\Framework\TestCase;
+
+class OrdersTest extends TestCase
+{
+    protected static $almaClient;
+    protected static $payment;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$almaClient = ClientTestHelper::getAlmaClient();
+        self::$payment = PaymentTestHelper::createPayment(26500, 3);
+    }
+
+    public function testCanCreateANewOrder()
+    {
+        $payment = self::$payment;
+        $order = $payment->orders[0];
+        $this->assertInstanceOf(Order::class, $order);
+        $this->assertEquals('ABC-123', $order->getMerchantReference());
+        $newOrder = self::$almaClient->payments->addOrder($payment->id, ['merchant_reference' => 'ABC-123-NEW']);
+        $this->assertInstanceOf(Order::class, $newOrder);
+        $this->assertEquals('ABC-123-NEW', $newOrder->getMerchantReference());
+    }
+
+    public function testCanUpdateOrderTracking()
+    {
+        $payment = self::$payment;
+        $order = $payment->orders[0];
+        $this->assertInstanceOf(Order::class, $order);
+        $this->assertNull($order->getCarrier());
+        $this->assertNull($order->getTrackingUrl());
+        $this->assertNull($order->getTrackingNumber());
+
+        $updatedOrder = self::$almaClient->orders->updateTracking($order->getExternalId(), null,null , 'https://tracking.com');
+        $this->assertInstanceOf(Order::class, $updatedOrder);
+        $this->assertNull($order->getCarrier());
+        $this->assertNull($updatedOrder->getTrackingNumber());
+        $this->assertEquals('https://tracking.com', $updatedOrder->getTrackingUrl());
+
+        $updatedOrder = self::$almaClient->orders->updateTracking($order->getExternalId(), 'UPS');
+        $this->assertInstanceOf(Order::class, $updatedOrder);
+        $this->assertEquals('UPS', $updatedOrder->getCarrier());
+        $this->assertNull($updatedOrder->getTrackingNumber());
+        $this->assertEquals('https://tracking.com', $updatedOrder->getTrackingUrl());
+
+        $updatedOrder = self::$almaClient->orders->updateTracking($order->getExternalId(), 'LAPOSTE','123456789' , 'https://laposte.com');
+        $this->assertInstanceOf(Order::class, $updatedOrder);
+        $this->assertEquals('LAPOSTE', $updatedOrder->getCarrier());
+        $this->assertEquals('123456789', $updatedOrder->getTrackingNumber());
+        $this->assertEquals('https://laposte.com', $updatedOrder->getTrackingUrl());
+    }
+}

--- a/tests/Integration/Endpoints/PaymentsTest.php
+++ b/tests/Integration/Endpoints/PaymentsTest.php
@@ -1,72 +1,51 @@
 <?php
 
-namespace Alma\API\Tests\Integration\Legacy\Endpoints;
+namespace Alma\API\Tests\Integration\Endpoints;
 
-use Alma\API\Client;
-use Alma\API\DependenciesError;
+use Alma\API\Entities\Payment;
 use Alma\API\ParamsError;
 use Alma\API\RequestError;
+use Alma\API\Tests\Integration\TestHelpers\ClientTestHelper;
+use Alma\API\Tests\Integration\TestHelpers\PaymentTestHelper;
 use PHPUnit\Framework\TestCase;
 
 final class PaymentsTest extends TestCase
 {
+    protected static $payment;
     protected static $almaClient;
-
     /**
-     * @throws DependenciesError
      * @throws ParamsError
+     * @throws RequestError
      */
     public static function setUpBeforeClass(): void
     {
-        self::$almaClient = new Client(
-            $_ENV['ALMA_API_KEY'],
-            ['mode' => 'test', 'api_root' => $_ENV['ALMA_API_ROOT'], 'force_tls' => false]
-        );
+        self::$payment = PaymentTestHelper::createPayment(26500, 3);
+        self::$almaClient = ClientTestHelper::getAlmaClient();
     }
-
-
-    private function paymentData($amount)
-    {
-        return [
-            'payment' => [
-                'purchase_amount' => $amount,
-                'shipping_address' => [
-                    'first_name' => 'Jane',
-                    'last_name' => 'Doe',
-                    'line1' => '2 rue de la rue',
-                    'city' => 'Paris',
-                    'postal_code' => '75002',
-                    'country' => 'FR',
-                ]
-            ]
-        ];
-    }
-
-    /**
-     * @param int $amount
-     * @throws RequestError
-     */
-    private function createPayment($amount)
-    {
-        return self::$almaClient->payments->create(self::paymentData($amount));
-    }
-
 
     /**
      * @throws RequestError
      */
     private function checkEligibility($amount, $eligible)
     {
-        $eligibility = self::$almaClient->payments->eligibility(self::paymentData($amount));
-        self::assertEquals($eligible, $eligibility->isEligible);
+        $eligibilityPayload = [
+            'purchase_amount' => $amount,
+            'queries' => [
+                ['installments_count' => 3],
+            ]
+        ];
+        $eligibility = self::$almaClient->payments->eligibility($eligibilityPayload);
+        $eligibility = $eligibility['general_3_0_0'];
+
+        $this->assertEquals($eligible, $eligibility->isEligible);
 
         if (!$eligible) {
-            self::assertArrayHasKey('purchase_amount', $eligibility->reasons);
-            self::assertEquals('invalid_value', $eligibility->reasons['purchase_amount']);
+            $this->assertArrayHasKey('purchase_amount', $eligibility->reasons);
+            $this->assertEquals('invalid_value', $eligibility->reasons['purchase_amount']);
 
-            self::assertArrayHasKey('purchase_amount', $eligibility->constraints);
-            self::assertArrayHasKey('minimum', $eligibility->constraints['purchase_amount']);
-            self::assertArrayHasKey('maximum', $eligibility->constraints['purchase_amount']);
+            $this->assertArrayHasKey('purchase_amount', $eligibility->constraints);
+            $this->assertArrayHasKey('minimum', $eligibility->constraints['purchase_amount']);
+            $this->assertArrayHasKey('maximum', $eligibility->constraints['purchase_amount']);
         }
     }
 
@@ -75,9 +54,9 @@ final class PaymentsTest extends TestCase
      */
     public function testCanCheckEligibility()
     {
-        self::checkEligibility(1, false);
-        self::checkEligibility(20000, true);
-        self::checkEligibility(500000, false);
+        $this->checkEligibility(1, false);
+        $this->checkEligibility(20000, true);
+        $this->checkEligibility(500000, false);
     }
 
     /**
@@ -85,8 +64,8 @@ final class PaymentsTest extends TestCase
      */
     public function testCanCreateAPayment()
     {
-        $payment = self::createPayment(26300);
-        self::assertEquals(26300, $payment->purchase_amount);
+        $payment = self::$payment;
+        $this->assertEquals(26500, $payment->purchase_amount);
     }
 
     /**
@@ -94,9 +73,9 @@ final class PaymentsTest extends TestCase
      */
     public function testCanFetchAPayment()
     {
-        $p1 = self::createPayment(26500);
+        $p1 = self::$payment;
         $p2 = self::$almaClient->payments->fetch($p1->id);
 
-        self::assertEquals($p1->id, $p2->id);
+        $this->assertEquals($p1->id, $p2->id);
     }
 }

--- a/tests/Integration/Endpoints/PaymentsTest.php
+++ b/tests/Integration/Endpoints/PaymentsTest.php
@@ -19,8 +19,8 @@ final class PaymentsTest extends TestCase
      */
     public static function setUpBeforeClass(): void
     {
-        self::$payment = PaymentTestHelper::createPayment(26500, 3);
-        self::$almaClient = ClientTestHelper::getAlmaClient();
+        PaymentsTest::$payment = PaymentTestHelper::createPayment(26500, 3);
+        PaymentsTest::$almaClient = ClientTestHelper::getAlmaClient();
     }
 
     /**
@@ -34,7 +34,7 @@ final class PaymentsTest extends TestCase
                 ['installments_count' => 3],
             ]
         ];
-        $eligibility = self::$almaClient->payments->eligibility($eligibilityPayload);
+        $eligibility = PaymentsTest::$almaClient->payments->eligibility($eligibilityPayload);
         $eligibility = $eligibility['general_3_0_0'];
 
         $this->assertEquals($eligible, $eligibility->isEligible);
@@ -64,7 +64,7 @@ final class PaymentsTest extends TestCase
      */
     public function testCanCreateAPayment()
     {
-        $payment = self::$payment;
+        $payment = PaymentsTest::$payment;
         $this->assertEquals(26500, $payment->purchase_amount);
     }
 
@@ -73,8 +73,8 @@ final class PaymentsTest extends TestCase
      */
     public function testCanFetchAPayment()
     {
-        $p1 = self::$payment;
-        $p2 = self::$almaClient->payments->fetch($p1->id);
+        $p1 = PaymentsTest::$payment;
+        $p2 = PaymentsTest::$almaClient->payments->fetch($p1->id);
 
         $this->assertEquals($p1->id, $p2->id);
     }

--- a/tests/Integration/TestHelpers/ClientTestHelper.php
+++ b/tests/Integration/TestHelpers/ClientTestHelper.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Alma\API\Tests\Integration\TestHelpers;
+
+use Alma\API\Client;
+
+class ClientTestHelper
+{
+    public static function getAlmaClient()
+    {
+        return new Client(
+            $_ENV['ALMA_API_KEY'],
+            ['mode' => 'test', 'api_root' => $_ENV['ALMA_API_ROOT'], 'force_tls' => false]
+        );
+    }
+
+}

--- a/tests/Integration/TestHelpers/PaymentTestHelper.php
+++ b/tests/Integration/TestHelpers/PaymentTestHelper.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Alma\API\Tests\Integration\TestHelpers;
+
+use Alma\API\Entities\Payment;
+use Alma\API\ParamsError;
+use Alma\API\RequestError;
+
+class PaymentTestHelper
+{
+    /**
+     * @param int $amount
+     * @return Payment
+     * @throws RequestError
+     * @throws ParamsError
+     */
+    public static function createPayment($amount, $installmentsCount)
+    {
+        return ClientTestHelper::getAlmaClient()->payments->create(self::paymentData($amount, $installmentsCount));
+    }
+
+    private static function paymentData($amount, $installmentsCount = 3)
+    {
+        return [
+            'payment' => [
+                'purchase_amount' => $amount,
+                'installments_count' => $installmentsCount,
+                'shipping_address' => [
+                    'first_name' => 'Jane',
+                    'last_name' => 'Doe',
+                    'line1' => '2 rue de la rue',
+                    'city' => 'Paris',
+                    'postal_code' => '75002',
+                    'country' => 'FR',
+                ]
+            ],
+            'customer' => [
+                'first_name' => 'Test Integration',
+                'last_name' => 'Ecom',
+                'email' => 'test@almapay.com',
+            ],
+            'order' => [
+                'merchant_reference' => 'ABC-123',
+            ]
+        ];
+    }
+
+
+}

--- a/tests/Unit/Endpoints/OrdersTest.php
+++ b/tests/Unit/Endpoints/OrdersTest.php
@@ -18,6 +18,7 @@ use Alma\API\Response;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Unit\Entities\OrderTest;
 
 class OrdersTest extends TestCase
 {
@@ -263,34 +264,12 @@ class OrdersTest extends TestCase
     }
 
     public function orderDataFactory(
-        $carrier = 'ups',
-        $tracking_number = 'ups_123456',
-        $tracking_url = 'http://tracking.url',
-        $comment = 'my comment',
-        $created = 1715331839,
-        $customer_url = 'http://customer.url',
-        $data = ['key' => 'value'],
-        $id = 'order_123',
-        $merchant_reference = 'my reference',
-        $merchant_url = 'http://merchant.url',
-        $payment = 'payment_123456',
-        $updated = 1715331839
+        $carrier,
+        $tracking_number,
+        $tracking_url
     )
     {
-        return [
-            'carrier' => $carrier,
-            'comment' => $comment,
-            'created' => $created,
-            'customer_url' => $customer_url,
-            'data' => $data,
-            'id' => $id,
-            'merchant_reference' => $merchant_reference,
-            'merchant_url' => $merchant_url,
-            'payment' => $payment,
-            'tracking_number' => $tracking_number,
-            'tracking_url' => $tracking_url,
-            'updated' => $updated
-        ];
+        return OrderTest::orderDataFactory($carrier, $tracking_number, $tracking_url);
     }
 
 

--- a/tests/Unit/Endpoints/OrdersTest.php
+++ b/tests/Unit/Endpoints/OrdersTest.php
@@ -218,7 +218,7 @@ class OrdersTest extends TestCase
             ->once()
             ->andReturn($this->requestObject);
         $order = $this->orderEndpoint->updateTracking('123', $carrier, $trackingNumber, $trackingUrl);
-        $this->isInstanceOf(Order::class, $order);
+        $this->assertInstanceOf(Order::class, $order);
         $this->assertEquals($carrier, $order->getCarrier());
         $this->assertEquals($trackingNumber, $order->getTrackingNumber());
         $this->assertEquals($trackingUrl, $order->getTrackingUrl());

--- a/tests/Unit/Endpoints/PaymentsTest.php
+++ b/tests/Unit/Endpoints/PaymentsTest.php
@@ -61,7 +61,6 @@ class PaymentsTest extends TestCase
                  "tracking_url":null,
                  "comment":null,
                  "created":1649672451,
-                 "updated":1649672451,
                  "customer_url":null,
                  "data":{},
                  "id":"order_11uPRjP4L9Dgbttx3cFUKGFPppdZIlrR2V",

--- a/tests/Unit/Endpoints/PaymentsTest.php
+++ b/tests/Unit/Endpoints/PaymentsTest.php
@@ -18,7 +18,7 @@ use Alma\API\Request;
 class PaymentsTest extends TestCase
 {
     const MERCHANT_REF = "merchant_ref";
-	const SERVER_REQUEST_ERROR_RESPONSE_JON = '{
+    const SERVER_REQUEST_ERROR_RESPONSE_JON = '{
            "payment_plan":[
               {
                  "customer_can_postpone":false,
@@ -56,8 +56,12 @@ class PaymentsTest extends TestCase
            ],
            "orders":[
               {
+                 "carrier":null,
+                 "tracking_number":null,
+                 "tracking_url":null,
                  "comment":null,
                  "created":1649672451,
+                 "updated":1649672451,
                  "customer_url":null,
                  "data":{},
                  "id":"order_11uPRjP4L9Dgbttx3cFUKGFPppdZIlrR2V",
@@ -80,112 +84,112 @@ class PaymentsTest extends TestCase
            ]
         }';
 
-	public function tearDown(): void
-	{
-		Mockery::close();
-	}
+    public function tearDown(): void
+    {
+        Mockery::close();
+    }
 
-	/**
-	 * Return input to test testPartialRefund
-	 * @return array[]
-	 */
-	public static function getPartialRefundData()
-	{
-		return [
-			[[
-				'id' => "some_id",
-				'amount' => 15000,
-				'merchant_ref' => self::MERCHANT_REF,
-				'comment' => "some comment"
-			]],
-			[[
-				'id' => "some_id",
-				'amount' => 15000,
-				'merchant_ref' => self::MERCHANT_REF
-			]],
-			[[
-				'id' => "some_id",
-				'amount' => 15000
-			]]
-		];
-	}
+    /**
+     * Return input to test testPartialRefund
+     * @return array[]
+     */
+    public static function getPartialRefundData()
+    {
+        return [
+            [[
+                'id' => "some_id",
+                'amount' => 15000,
+                'merchant_ref' => self::MERCHANT_REF,
+                'comment' => "some comment"
+            ]],
+            [[
+                'id' => "some_id",
+                'amount' => 15000,
+                'merchant_ref' => self::MERCHANT_REF
+            ]],
+            [[
+                'id' => "some_id",
+                'amount' => 15000
+            ]]
+        ];
+    }
 
-	/**
-	 * Return invalid input to test testPartialRefund
-	 * @return array[]
-	 */
-	public static function getPartialRefundInvalidData()
-	{
-		return [
-			[[
-				'id' => "negative_amount",
-				'amount' => -1
-			], ParametersException::class],
-			[[
-				'id' => "",
-				'amount' => 1500,
-				'merchant_ref' => "no id",
-			], ParametersException::class],
-		];
-	}
+    /**
+     * Return invalid input to test testPartialRefund
+     * @return array[]
+     */
+    public static function getPartialRefundInvalidData()
+    {
+        return [
+            [[
+                'id' => "negative_amount",
+                'amount' => -1
+            ], ParametersException::class],
+            [[
+                'id' => "",
+                'amount' => 1500,
+                'merchant_ref' => "no id",
+            ], ParametersException::class],
+        ];
+    }
 
-	/**
-	 * Return input to test testFullRefund
-	 * @return array[]
-	 */
-	public static function getFullRefundData()
-	{
-		return [
-			[[
-				'id' => "some_id",
-				'merchant_ref' => self::MERCHANT_REF,
-				'comment' => "some comment"
-			]],
-			[[
-				'id' => "some_id",
-				'merchant_ref' => self::MERCHANT_REF
-			]],
-			[[
-				'id' => "some_id",
-			]]
-		];
-	}
+    /**
+     * Return input to test testFullRefund
+     * @return array[]
+     */
+    public static function getFullRefundData()
+    {
+        return [
+            [[
+                'id' => "some_id",
+                'merchant_ref' => self::MERCHANT_REF,
+                'comment' => "some comment"
+            ]],
+            [[
+                'id' => "some_id",
+                'merchant_ref' => self::MERCHANT_REF
+            ]],
+            [[
+                'id' => "some_id",
+            ]]
+        ];
+    }
 
-	/**
-	 * Return input to test testRefund
-	 * @return array[]
-	 */
-	public static function getRefundData()
-	{
-		return [
-			[[
-				'id' => "some_id",
-				'amount' => 15000,
-				'merchant_ref' => self::MERCHANT_REF,
-			]],
-			[[
-				'id' => "some_id",
-			]],
-			[[
-				'id' => "some_id",
-				'amount' => 15000
-			]]
-		];
-	}
+    /**
+     * Return input to test testRefund
+     * @return array[]
+     */
+    public static function getRefundData()
+    {
+        return [
+            [[
+                'id' => "some_id",
+                'amount' => 15000,
+                'merchant_ref' => self::MERCHANT_REF,
+            ]],
+            [[
+                'id' => "some_id",
+            ]],
+            [[
+                'id' => "some_id",
+                'amount' => 15000
+            ]]
+        ];
+    }
 
-	/**
-	 * Return invalid input to test testFullRefund
-	 * @return array[]
-	 */
-	public static function getFullRefundInvalidData()
-	{
-		return [
-			[[
-				'id' => "",
-				'merchant_ref' => "no id",
-			], ParametersException::class],
-		];
-	}
+    /**
+     * Return invalid input to test testFullRefund
+     * @return array[]
+     */
+    public static function getFullRefundInvalidData()
+    {
+        return [
+            [[
+                'id' => "",
+                'merchant_ref' => "no id",
+            ], ParametersException::class],
+        ];
+    }
 
     /**
      * Mock ClientContext, Response and Request to allow us to test
@@ -232,71 +236,71 @@ class PaymentsTest extends TestCase
         }
     }
 
-	private function callFullRefund($payments, $data)
-	{
-		if (isset($data['merchant_ref']) && isset($data['comment'])) {
-			$payments->fullRefund($data['id'], $data['merchant_ref'], $data['comment']);
-		} elseif (isset($data['merchant_ref'])) {
-			$payments->fullRefund($data['id'], $data['merchant_ref']);
-		} elseif (isset($data['comment'])) {
-			$payments->fullRefund($data['id'], '', $data['comment']);
-		} else {
-			$payments->fullRefund($data['id']);
-		}
-	}
+    private function callFullRefund($payments, $data)
+    {
+        if (isset($data['merchant_ref']) && isset($data['comment'])) {
+            $payments->fullRefund($data['id'], $data['merchant_ref'], $data['comment']);
+        } elseif (isset($data['merchant_ref'])) {
+            $payments->fullRefund($data['id'], $data['merchant_ref']);
+        } elseif (isset($data['comment'])) {
+            $payments->fullRefund($data['id'], '', $data['comment']);
+        } else {
+            $payments->fullRefund($data['id']);
+        }
+    }
 
-	private function callRefund($payments, $data)
-	{
-		if (isset($data['merchant_ref']) && isset($data['amount'])) {
-			$payments->refund($data['id'], $data['amount'], $data['merchant_ref']);
-		} elseif (isset($data['amount'])) {
-			$payments->refund($data['id'], $data['amount']);
-		} else {
-			$payments->refund($data['id']);
-		}
-	}
+    private function callRefund($payments, $data)
+    {
+        if (isset($data['merchant_ref']) && isset($data['amount'])) {
+            $payments->refund($data['id'], $data['amount'], $data['merchant_ref']);
+        } elseif (isset($data['amount'])) {
+            $payments->refund($data['id'], $data['amount']);
+        } else {
+            $payments->refund($data['id']);
+        }
+    }
 
-	/**
-	 * Mock ClientContext, Response and Request to allow us to test
-	 * Payment without sending any requests but returns an error
-	 */
-	private function mockServerRequestError()
-	{
-		// ClientContext
-		$clientContext = Mockery::mock(ClientContext::class);
-		$clientContext->shouldReceive('urlFor');
-		$clientContext->shouldReceive('getUserAgentString');
-		$clientContext->shouldReceive('forcedTLSVersion');
+    /**
+     * Mock ClientContext, Response and Request to allow us to test
+     * Payment without sending any requests but returns an error
+     */
+    private function mockServerRequestError()
+    {
+        // ClientContext
+        $clientContext = Mockery::mock(ClientContext::class);
+        $clientContext->shouldReceive('urlFor');
+        $clientContext->shouldReceive('getUserAgentString');
+        $clientContext->shouldReceive('forcedTLSVersion');
 
-		// Response
-		$json = self::SERVER_REQUEST_ERROR_RESPONSE_JON;
+        // Response
+        $json = self::SERVER_REQUEST_ERROR_RESPONSE_JON;
 
-		$responseMock = Mockery::mock(Response::class);
-		$responseMock->shouldReceive('isError')->andReturn(true);
-		$responseMock->json = json_decode($json, true);
-		$responseMock->errorMessage = "a very important error message";
+        $responseMock = Mockery::mock(Response::class);
+        $responseMock->shouldReceive('isError')->andReturn(true);
+        $responseMock->json = json_decode($json, true);
+        $responseMock->errorMessage = "a very important error message";
 
-		// Request
-		$requestMock = Mockery::mock(Request::class);
-		$requestMock->shouldReceive('setRequestBody');
-		$requestMock->shouldReceive('post')->andReturn($responseMock);
-		return $requestMock;
-	}
+        // Request
+        $requestMock = Mockery::mock(Request::class);
+        $requestMock->shouldReceive('setRequestBody');
+        $requestMock->shouldReceive('post')->andReturn($responseMock);
+        return $requestMock;
+    }
 
-	/**
-	 * Ensure that the methods exists
-	 */
-	public function testRefundMethodExist()
-	{
-		$clientContext = Mockery::mock(ClientContext::class);
+    /**
+     * Ensure that the methods exists
+     */
+    public function testRefundMethodExist()
+    {
+        $clientContext = Mockery::mock(ClientContext::class);
 
-		$payments = new Payments($clientContext);
+        $payments = new Payments($clientContext);
 
-		$this->assertTrue(method_exists($payments, 'partialRefund'));
-		$this->assertTrue(method_exists($payments, 'fullRefund'));
-		# ensure backward compatibility
-		$this->assertTrue(method_exists($payments, 'refund'));
-	}
+        $this->assertTrue(method_exists($payments, 'partialRefund'));
+        $this->assertTrue(method_exists($payments, 'fullRefund'));
+        # ensure backward compatibility
+        $this->assertTrue(method_exists($payments, 'refund'));
+    }
 
     /**
      * Test the partialRefund method with valid datas
@@ -312,14 +316,12 @@ class PaymentsTest extends TestCase
         // Payment
         $payments = Mockery::mock(Payments::class)
             ->shouldAllowMockingProtectedMethods()
-            ->makePartial()
-        ;
+            ->makePartial();
         $id = $data['id'];
         $payments->shouldReceive('request')
             ->with("/v1/payments/$id/refund")
             ->once()
-            ->andReturn($this->mockServerRequest())
-        ;
+            ->andReturn($this->mockServerRequest());
         $payments->setClientContext($clientContext);
 
         /* Test */
@@ -341,13 +343,11 @@ class PaymentsTest extends TestCase
         // Payment
         $payments = Mockery::mock(Payments::class)
             ->shouldAllowMockingProtectedMethods()
-            ->makePartial()
-        ;
+            ->makePartial();
         $id = $data['id'];
         $payments->shouldReceive('request')
             ->with("/v1/payments/$id/refund")
-            ->andReturn($this->mockServerRequest())
-        ;
+            ->andReturn($this->mockServerRequest());
         $payments->setClientContext($clientContext);
 
         $this->expectException($expectedException);
@@ -368,14 +368,12 @@ class PaymentsTest extends TestCase
         // Payment
         $payments = Mockery::mock(Payments::class)
             ->shouldAllowMockingProtectedMethods()
-            ->makePartial()
-        ;
+            ->makePartial();
         $id = $data['id'];
         $payments->shouldReceive('request')
             ->with("/v1/payments/$id/refund")
             ->once()
-            ->andReturn($this->mockServerRequest())
-        ;
+            ->andReturn($this->mockServerRequest());
         $payments->setClientContext($clientContext);
 
         /* Test */
@@ -395,14 +393,12 @@ class PaymentsTest extends TestCase
         // Payment
         $payments = Mockery::mock(Payments::class)
             ->shouldAllowMockingProtectedMethods()
-            ->makePartial()
-        ;
+            ->makePartial();
         $id = $data['id'];
         $payments->shouldReceive('request')
             ->with("/v1/payments/$id/refund")
             ->once()
-            ->andReturn($this->mockServerRequest())
-        ;
+            ->andReturn($this->mockServerRequest());
         $payments->setClientContext($clientContext);
 
         /* Test */
@@ -421,13 +417,11 @@ class PaymentsTest extends TestCase
         // Payment
         $payments = Mockery::mock(Payments::class)
             ->shouldAllowMockingProtectedMethods()
-            ->makePartial()
-        ;
+            ->makePartial();
         $id = $data['id'];
         $payments->shouldReceive('request')
             ->with("/v1/payments/$id/refund")
-            ->andReturn($this->mockServerRequest())
-        ;
+            ->andReturn($this->mockServerRequest());
         $payments->setClientContext($clientContext);
 
         $this->expectException($expectedException);
@@ -445,13 +439,11 @@ class PaymentsTest extends TestCase
         // Payment
         $payments = Mockery::mock(Payments::class)
             ->shouldAllowMockingProtectedMethods()
-            ->makePartial()
-        ;
+            ->makePartial();
         $payments->shouldReceive('request')
             ->with("/v1/payments/$id/refund")
             ->once()
-            ->andReturn($this->mockServerRequestError())
-        ;
+            ->andReturn($this->mockServerRequestError());
         $payments->setClientContext($clientContext);
 
         $this->expectException(RequestException::class);

--- a/tests/Unit/Entities/OrderTest.php
+++ b/tests/Unit/Entities/OrderTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Unit\Entities;
+
+use Alma\API\Entities\Order;
+use PHPUnit\Framework\TestCase;
+
+class OrderTest extends TestCase
+{
+
+    public function testOrderGetters()
+    {
+        $orderData = $this->orderDataFactory();
+        $order = new Order($orderData);
+
+        $this->assertEquals($orderData['carrier'], $order->getCarrier());
+        $this->assertEquals($orderData['tracking_number'], $order->getTrackingNumber());
+        $this->assertEquals($orderData['tracking_url'], $order->getTrackingUrl());
+        $this->assertEquals($orderData['payment'], $order->payment);
+        $this->assertEquals($orderData['payment'], $order->getPaymentId());
+        $this->assertEquals($orderData['merchant_reference'], $order->merchant_reference);
+        $this->assertEquals($orderData['merchant_reference'], $order->getMerchantReference());
+        $this->assertEquals($orderData['merchant_url'], $order->getMerchantUrl());
+        $this->assertEquals($orderData['merchant_url'], $order->merchant_url );
+        $this->assertEquals($orderData['data'], $order->data);
+        $this->assertEquals($orderData['data'], $order->getOrderData());
+        $this->assertEquals($orderData['comment'], $order->getComment());
+        $this->assertEquals($orderData['created'], $order->getCreatedAt());
+        $this->assertEquals($orderData['customer_url'], $order->getCustomerUrl());
+        $this->assertEquals($orderData['id'], $order->id);
+        $this->assertEquals($orderData['id'], $order->getExternalId());
+        $this->assertEquals($orderData['updated'], $order->getUpdatedAt());
+    }
+
+
+    public static function orderDataFactory(
+        $carrier = 'ups',
+        $tracking_number = 'ups_123456',
+        $tracking_url = 'http://tracking.url',
+        $comment = 'my comment',
+        $created = 1715331839,
+        $customer_url = 'http://customer.url',
+        $data = ['key' => 'value'],
+        $id = 'order_123',
+        $merchant_reference = 'my reference',
+        $merchant_url = 'https://merchant.url',
+        $payment = 'payment_123456',
+        $updated = 1715331845
+    )
+    {
+        return [
+            'carrier' => $carrier,
+            'comment' => $comment,
+            'created' => $created,
+            'customer_url' => $customer_url,
+            'data' => $data,
+            'id' => $id,
+            'merchant_reference' => $merchant_reference,
+            'merchant_url' => $merchant_url,
+            'payment' => $payment,
+            'tracking_number' => $tracking_number,
+            'tracking_url' => $tracking_url,
+            'updated' => $updated
+        ];
+    }
+}


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding Linear task or Sentry issue. -->

https://linear.app/almapay/issue/ECOM-1781/[🧩-php-client]-update-php-client-to-be-able-to-update-orders-shipping
### Code changes

Change Order of object creation and add updateTracking method in Orders endpoint.
Normaly it's compatible with old versions.

### How to test

Test all CMS to check order usage

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [x] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [x] The PR implements the changes asked in the referenced task / issue
- [x] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [x] The tests are relevant, and cover the corner/error cases, not only the happy path
- [x] You understand the impact of this PR on existing code/features

### Non applicable

- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)
- [ ] The changes include adequate logging and Datadog traces

<!-- Move here non applicable items of the checklist, if any -->