### PR TITLE
Fix typo in release-publish workflow

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -98,7 +98,7 @@ jobs:
               draft: false,
               make_latest: true,
               tag_name: "${{ steps.fetch-release-draft.outputs.name }}",
-              target_commitish: "refs/heads/main
+              target_commitish: "refs/heads/main"
             });
 
       - name: Format release notes for Slack


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding Linear task or Sentry issue. -->

I forgot a closing double quote here :  https://github.com/alma/alma-php-client/pull/118/files
(I copy/pasted the same code on the other repositories but happily I only made the mistake on this one)

This made the workflow fail, see here: https://github.com/alma/alma-php-client/actions/runs/10143933279/job/28046366381
