### PR TITLE
[DEVX] Fix CI for PHP versions > 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,11 @@ jobs:
           grep -r -l "$string" tests/ | xargs sed -i "s/$string//g"
 
       - name: PHPUnit
-        run: composer exec phpunit -- --configuration phpunit.ci.xml --coverage-xml ./.coverage
+        run: |
+          case ${{ matrix.php }} in
+            8.1|8.2|8.3 ) composer exec phpunit -- --configuration phpunit.ci.8.xml --coverage-xml ./.coverage;;
+            *) composer exec phpunit -- --configuration phpunit.ci.xml --coverage-xml ./.coverage;;
+          esac
         env:
           XDEBUG_MODE: coverage
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ phpunit.xml
 composer.lock
 .DS_Store
 .env
+.coverage/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ ARG COMPOSER_VERSION
 
 FROM composer:${COMPOSER_VERSION} as composer
 FROM php:${PHP_VERSION}-fpm
+ARG PHP_VERSION
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -15,6 +16,11 @@ RUN apt update && \
     && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+
+RUN case ${PHP_VERSION} in \
+        8.0|8.1|8.2|8.3 ) pecl install xdebug-3.3.2 && docker-php-ext-enable xdebug;; \
+        *) pecl install xdebug-2.9.8 && docker-php-ext-enable xdebug;; \
+    esac
 
 RUN usermod -u 1000 www-data
 RUN groupmod -g 1000 www-data

--- a/Dockerfile.legacy
+++ b/Dockerfile.legacy
@@ -20,6 +20,10 @@ RUN apt update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 
+# Install xdebug for code coverage
+RUN pecl install xdebug-2.5.5 \
+&& docker-php-ext-enable xdebug
+
 RUN usermod -u 1000 www-data
 RUN groupmod -g 1000 www-data
 

--- a/Taskfile.php.yml
+++ b/Taskfile.php.yml
@@ -27,9 +27,9 @@ tasks:
     cmds:
       - >-
         {{ if eq .PHP_VERSION "5.6" "7.0" }}
-        docker compose run {{ .COMPOSE_SERVICE }} ./tests/legacy_tests.sh
+        docker compose run --rm {{ .COMPOSE_SERVICE }} ./tests/legacy_tests.sh
         {{ else }}
-        docker compose run {{ .COMPOSE_SERVICE }} composer exec phpunit --verbose -- --configuration phpunit.dist.xml --testsuite "Alma PHP Client Unit Test Suite"
+        docker compose run --rm {{ .COMPOSE_SERVICE }} composer exec phpunit --verbose -- --configuration {{ .PHPUNIT_FILE }} --testsuite "Alma PHP Client Unit Test Suite" --coverage-xml ./.coverage
         {{ end }}
 
   tests:integration:
@@ -39,9 +39,9 @@ tasks:
     cmds:
        - >-
           {{ if eq .PHP_VERSION "5.6" "7.0" }}
-          docker compose run {{ .COMPOSE_SERVICE }} ./tests/legacy_integration_tests.sh
+          docker compose run --rm {{ .COMPOSE_SERVICE }} ./tests/legacy_integration_tests.sh
           {{ else }}
-          docker compose run {{ .COMPOSE_SERVICE }} composer exec phpunit --verbose -- --configuration phpunit.dist.xml --testsuite "Alma PHP Client Integration Test Suite"
+          docker compose run --rm {{ .COMPOSE_SERVICE }} composer exec phpunit --verbose -- --configuration {{ .PHPUNIT_FILE }} --testsuite "Alma PHP Client Integration Test Suite"
           {{ end }}
 
   shell:
@@ -49,5 +49,5 @@ tasks:
     deps:
       - docker:build
     cmds:
-      - sed 's/{MYVERSION}/{{ .PHPUNIT_VERSION }}/g' phpunit.dist.xml > phpunit.xml
-      - docker compose run {{ .COMPOSE_SERVICE }} bash
+      - sed 's/{MYVERSION}/{{ .PHPUNIT_VERSION }}/g' {{ .PHPUNIT_FILE }} > phpunit.xml
+      - docker compose run --rm {{ .COMPOSE_SERVICE }} bash

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -44,14 +44,17 @@ includes:
     taskfile: Taskfile.php.yml
     vars:
       PHP_VERSION: "8.1"
+      PHPUNIT_FILE: phpunit.dist.8.xml
   "8.2":
     taskfile: Taskfile.php.yml
     vars:
       PHP_VERSION: "8.2"
+      PHPUNIT_FILE: phpunit.dist.8.xml
   "8.3":
     taskfile: Taskfile.php.yml
     vars:
       PHP_VERSION: "8.3"
+      PHPUNIT_FILE: phpunit.dist.8.xml
 
 tasks:
   default:

--- a/compose.yml
+++ b/compose.yml
@@ -12,6 +12,8 @@ services:
     volumes:
       - ./:/app
       - /app/vendor
+    environment:
+      XDEBUG_MODE: coverage
 
   php-legacy:
     user: ${UID:-1000}:${GID:-1000}

--- a/phpunit.ci.8.xml
+++ b/phpunit.ci.8.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  bootstrap="vendor/autoload.php"
+  backupGlobals="false"
+  colors="true"
+  processIsolation="false"
+  stopOnFailure="true"
+  beStrictAboutTestsThatDoNotTestAnything="false"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+  cacheDirectory=".phpunit.cache"
+  backupStaticProperties="false">
+
+  <testsuites>
+    <testsuite name="Alma PHP Client Unit Test Suite">
+      <directory>tests/Unit</directory>
+    </testsuite>
+  </testsuites>
+
+  <coverage includeUncoveredFiles="true"
+    pathCoverage="false"
+    ignoreDeprecatedCodeUnits="true"
+    disableCodeCoverageIgnore="true">
+  </coverage>
+
+  <source>
+    <include>
+      <directory suffix=".php">./src/*</directory>
+    </include>
+  </source>
+
+</phpunit>

--- a/phpunit.dist.8.xml
+++ b/phpunit.dist.8.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+        bootstrap="vendor/autoload.php" 
+        backupGlobals="false" 
+        colors="true" 
+        testdox="true" 
+        displayDetailsOnTestsThatTriggerDeprecations="true" 
+        processIsolation="false" 
+        stopOnFailure="false" 
+        beStrictAboutTestsThatDoNotTestAnything="false" 
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" 
+        cacheDirectory=".phpunit.cache" 
+        backupStaticProperties="false">
+
+  <testsuites>
+    <testsuite name="Alma PHP Client Unit Test Suite">
+      <directory>tests/Unit</directory>
+    </testsuite>
+    <testsuite name="Alma PHP Client Integration Test Suite">
+      <directory>tests/Integration</directory>
+    </testsuite>
+  </testsuites>
+
+  <coverage includeUncoveredFiles="true"
+    pathCoverage="false"
+    ignoreDeprecatedCodeUnits="true"
+    disableCodeCoverageIgnore="true">
+  </coverage>
+
+  <source>
+    <include>
+      <directory suffix=".php">./src/*</directory>
+    </include>
+  </source>
+
+  <php>
+    <env name="ALMA_API_KEY" value="sk_test_*******"/>
+    <env name="ALMA_API_ROOT" value="alma-api-url"/>
+  </php>
+</phpunit>

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" testdox="true" displayDetailsOnTestsThatTriggerDeprecations="true" processIsolation="false" stopOnFailure="false" beStrictAboutTestsThatDoNotTestAnything="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+<phpunit bootstrap="vendor/autoload.php"
+        backupGlobals="false"
+        colors="true"
+        processIsolation="false"
+        stopOnFailure="false"
+        beStrictAboutTestsThatDoNotTestAnything="false">
   <testsuites>
     <testsuite name="Alma PHP Client Unit Test Suite">
       <directory>tests/Unit</directory>
@@ -8,6 +13,11 @@
       <directory>tests/Integration</directory>
     </testsuite>
   </testsuites>
+  <filter>
+    <whitelist processUncoveredFilesFromWhitelist="true">
+        <directory suffix=".php">./src/*</directory>
+    </whitelist>
+</filter>
   <php>
     <env name="ALMA_API_KEY" value="sk_test_*******"/>
     <env name="ALMA_API_ROOT" value="alma-api-url"/>

--- a/tests/legacy_tests.sh
+++ b/tests/legacy_tests.sh
@@ -11,4 +11,4 @@ string=': void'
 grep -r -l "$string" tests/ | xargs sed -i "s/$string//g"
 
 # Run tests
-composer exec phpunit --verbose -- --configuration phpunit.dist.xml --testsuite "Alma PHP Client Unit Test Suite"
+composer exec phpunit --verbose -- --configuration phpunit.dist.xml --testsuite "Alma PHP Client Unit Test Suite" --coverage-xml ./.coverage


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding Linear task or Sentry issue. -->

CI is failing for PHP v8.1, v8.2 and v8.3, see https://github.com/alma/alma-php-client/actions/runs/10146046469/job/28053200512
=> The XML configuration for PHPUnit used in the CI needs to be changed for these versions.

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
* Add a specific phpunit.xml file for PHP versions > 8.0 (One for the CI, one used locally in Taskfile)
* Enable the coverage for tests running through tasks, so that developers can check the coverage locally

