### PR TITLE
Add DataExports endpoints

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -70,6 +70,11 @@ class Client
      * @var Endpoints\Insurance
      */
     public $insurance;
+
+    /**
+     * @var Endpoints\DataExports
+     */
+    public $dataExports;
     /*************************/
 
     /**
@@ -150,6 +155,7 @@ class Client
         $this->shareOfCheckout = new Endpoints\ShareOfCheckout($this->context);
         $this->webhooks = new Endpoints\Webhooks($this->context);
         $this->insurance = new Endpoints\Insurance($this->context);
+        $this->dataExports = new Endpoints\DataExports($this->context);
     }
 
     private function initUserAgent()

--- a/src/Endpoints/DataExports.php
+++ b/src/Endpoints/DataExports.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Copyright (c) 2018 Alma / Nabla SAS
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma / Nabla SAS <contact@getalma.eu>
+ * @copyright Copyright (c) 2018 Alma / Nabla SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ *
+ */
+
+namespace Alma\API\Endpoints;
+
+use Alma\API\Entities\DataExport;
+use Alma\API\ParamsError;
+use Alma\API\RequestError;
+
+class DataExports extends Base
+{
+    const DATA_EXPORTS_PATH = '/v1/data-exports';
+
+    /**
+     * @param $data
+     * @return DataExport
+     * @throws ParamsError
+     * @throws RequestError
+     */
+    public function create($data)
+    {
+        $res = $this->request(self::DATA_EXPORTS_PATH)->setRequestBody($data)->post();
+
+        if ($res->isError()) {
+            throw new RequestError($res->errorMessage, null, $res);
+        }
+
+        return new DataExport($res->json);
+    }
+
+    /**
+     * @param $data
+     * @return DataExport
+     * @throws ParamsError
+     * @throws RequestError
+     */
+    public function fetch($reportId)
+    {
+        $res = $this->request(self::DATA_EXPORTS_PATH . '/' . $reportId)->get();
+
+        if ($res->isError()) {
+            throw new RequestError($res->errorMessage, null, $res);
+        }
+
+        return new DataExport($res->json);
+    }
+
+    /**
+     * @param $reportId
+     * @param $format
+     *
+     * @return mixed
+     * @throws RequestError
+     */
+    public function download($reportId, $format)
+    {
+        $res = $this->request(self::DATA_EXPORTS_PATH . '/' . $reportId)
+            ->setQueryParams(['format' => $format])
+            ->get();
+
+        if ($res->isError()) {
+            throw new RequestError($res->errorMessage, null, $res);
+        }
+
+        return $res->data;
+    }
+}

--- a/src/Entities/DataExport.php
+++ b/src/Entities/DataExport.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (c) 2018 Alma / Nabla SAS
+ * Copyright (c) 2018 Alma / Nabla SAS.
  *
  * THE MIT LICENSE
  *
@@ -20,45 +20,49 @@
  * @author    Alma / Nabla SAS <contact@getalma.eu>
  * @copyright Copyright (c) 2018 Alma / Nabla SAS
  * @license   https://opensource.org/licenses/MIT The MIT License
- *
  */
 
-namespace Alma\API;
+namespace Alma\API\Entities;
 
-class Response
+class DataExport extends Base
 {
-    public $responseCode;
-    public $json;
-    public $data;
-    public $errorMessage;
+    public $complete;
 
-    public function __construct($curlHandle, $curlResult)
+    public $created;
+
+    public $end;
+
+    public $holder_id;
+
+    public $id;
+
+    public $include_child_accounts;
+
+    public $merchant;
+
+    public $receivable_export_type;
+
+    public $start;
+
+    public $type;
+
+    public $updated;
+
+    public $url_csv;
+
+    public $url_pdf;
+
+    public $url_xlsx;
+
+    public $url_xml;
+
+    public $url_zip;
+
+    /**
+     * @param array $attributes
+     */
+    public function __construct($attributes)
     {
-        $this->responseCode = curl_getinfo($curlHandle, CURLINFO_HTTP_CODE);
-        $this->json = json_decode($curlResult, true);
-        $this->data = $curlResult;
-
-        if ($this->isError()) {
-            if ($this->json && array_key_exists('message', $this->json)) {
-                $this->errorMessage = $this->json['message'];
-            } else {
-                $this->errorMessage = curl_error($curlHandle);
-            }
-        }
-    }
-
-    public function isError()
-    {
-        return $this->responseCode >= 400 && $this->responseCode < 600;
-    }
-}
-
-class EmptyResponse extends Response
-{
-    public function __construct()
-    {
-        $this->errorMessage = null;
-        $this->json = [];
-        $this->responseCode = null;
+        parent::__construct($attributes);
     }
 }


### PR DESCRIPTION
### Reason for change

Missing DataExport methods/endpoint.

### Code changes

- Added endpoint for DataExport and added to client.
- Added entity class with properties from API docs (https://docs.almapay.com/reference/data-export)
- Added `data` property to response class, since downloading the generated report file is not a JSON response and needs access to the "raw" response data.

### How to test

Call methods `create`, `fetch` and `download` on the DataExports endpoint, check responses and generated file output.

### Checklist for authors and reviewers

Have not written tests yet, since I don't have access to the internal docs and tools. Feel free to amend or give guidance on how to proceed. Thanks.
