### PR TITLE
Create endpoint and formatter for gather cms data

### DIFF
--- a/src/Endpoints/Merchants.php
+++ b/src/Endpoints/Merchants.php
@@ -27,58 +27,76 @@ namespace Alma\API\Endpoints;
 
 use Alma\API\Entities\FeePlan;
 use Alma\API\Entities\Merchant;
+use Alma\API\Entities\MerchantData\MerchantData;
+use Alma\API\Exceptions\RequestException;
 use Alma\API\RequestError;
 
 class Merchants extends Base
 {
-    const MERCHANTS_PATH = '/v1/merchants';
-    const ME_PATH = '/v1/me';
+	const MERCHANTS_PATH = '/v1/merchants';
+	const ME_PATH = '/v1/me';
 
-    /**
-     * @return Merchant
-     * @throws RequestError
-     */
-    public function me()
-    {
-        $res = $this->request(self::ME_PATH . '/extended-data')->get();
+	/**
+	 * @return Merchant
+	 * @throws RequestError
+	 */
+	public function me()
+	{
+		$res = $this->request(self::ME_PATH . '/extended-data')->get();
 
-        if ($res->isError()) {
-            throw new RequestError($res->errorMessage, null, $res);
-        }
+		if ($res->isError()) {
+			throw new RequestError($res->errorMessage, null, $res);
+		}
 
-        return new Merchant($res->json);
-    }
+		return new Merchant($res->json);
+	}
 
-    /**
-     * @param $kind string  Either FeePlan::KIND_GENERAL or FeePlan::KIND_POS. The former is applied to online payments,
-     *                      while the latter will be used when creating a Payment with origin=pos_* for
-     *                      retail/point-of-sale use cases. Defaults to FeePlan::KIND_GENERAL
-     * @param string|int[] $installmentsCounts Only include fee plans that match the given installments counts, or use
-     *                                         the string "all" (default) to get all available fee plans
-     * @param bool $includeDeferred Include deferred fee plans (i.e. Pay Later plans) in the response
-     * @return FeePlan[] An array of available fee plans (some might be disabled, check FeePlan->allowed for each)
-     * @throws RequestError
-     */
-    public function feePlans($kind = FeePlan::KIND_GENERAL, $installmentsCounts = "all", $includeDeferred = false)
-    {
-        if (is_array($installmentsCounts)) {
-            $only = implode(",", $installmentsCounts);
-        } else {
-            $only = $installmentsCounts;
-        }
+	/**
+	 * @param $kind string  Either FeePlan::KIND_GENERAL or FeePlan::KIND_POS. The former is applied to online payments,
+	 *                      while the latter will be used when creating a Payment with origin=pos_* for
+	 *                      retail/point-of-sale use cases. Defaults to FeePlan::KIND_GENERAL
+	 * @param string|int[] $installmentsCounts Only include fee plans that match the given installments counts, or use
+	 *                                         the string "all" (default) to get all available fee plans
+	 * @param bool $includeDeferred Include deferred fee plans (i.e. Pay Later plans) in the response
+	 * @return FeePlan[] An array of available fee plans (some might be disabled, check FeePlan->allowed for each)
+	 * @throws RequestError
+	 */
+	public function feePlans($kind = FeePlan::KIND_GENERAL, $installmentsCounts = "all", $includeDeferred = false)
+	{
+		if (is_array($installmentsCounts)) {
+			$only = implode(",", $installmentsCounts);
+		} else {
+			$only = $installmentsCounts;
+		}
 
-        $res = $this->request(self::ME_PATH . "/fee-plans")->setQueryParams(array(
-            "kind" => $kind,
-            "only" => $only,
-            "deferred" => $includeDeferred ? "true" : "false" // Avoid conversion to "0"/"1" our API doesn't recognize
-        ))->get();
+		$res = $this->request(self::ME_PATH . "/fee-plans")->setQueryParams(array(
+			"kind" => $kind,
+			"only" => $only,
+			"deferred" => $includeDeferred ? "true" : "false" // Avoid conversion to "0"/"1" our API doesn't recognize
+		))->get();
 
-        if ($res->isError()) {
-            throw new RequestError($res->errorMessage, null, $res);
-        }
+		if ($res->isError()) {
+			throw new RequestError($res->errorMessage, null, $res);
+		}
 
-        return array_map(function ($val) {
-            return new FeePlan($val);
-        }, $res->json);
-    }
+		return array_map(function ($val) {
+			return new FeePlan($val);
+		}, $res->json);
+	}
+
+	/**
+	 * @param string $url The URL to send to Alma for integrations configuration
+	 * @throws RequestException
+	 * @throws RequestError
+	 */
+	public function sendIntegrationsConfigurationsUrl($url)
+	{
+		$res = $this->request(self::ME_PATH . "/integrations/configurations")->setRequestBody(array(
+			"endpoint_url" => $url
+		))->post();
+
+		if ($res->isError()) {
+			throw new RequestException($res->errorMessage, null, $res);
+		}
+	}
 }

--- a/src/Endpoints/Merchants.php
+++ b/src/Endpoints/Merchants.php
@@ -33,70 +33,69 @@ use Alma\API\RequestError;
 
 class Merchants extends Base
 {
-	const MERCHANTS_PATH = '/v1/merchants';
-	const ME_PATH = '/v1/me';
+    const ME_PATH = '/v1/me';
 
-	/**
-	 * @return Merchant
-	 * @throws RequestError
-	 */
-	public function me()
-	{
-		$res = $this->request(self::ME_PATH . '/extended-data')->get();
+    /**
+     * @return Merchant
+     * @throws RequestError
+     */
+    public function me()
+    {
+        $res = $this->request(self::ME_PATH . '/extended-data')->get();
 
-		if ($res->isError()) {
-			throw new RequestError($res->errorMessage, null, $res);
-		}
+        if ($res->isError()) {
+            throw new RequestError($res->errorMessage, null, $res);
+        }
 
-		return new Merchant($res->json);
-	}
+        return new Merchant($res->json);
+    }
 
-	/**
-	 * @param $kind string  Either FeePlan::KIND_GENERAL or FeePlan::KIND_POS. The former is applied to online payments,
-	 *                      while the latter will be used when creating a Payment with origin=pos_* for
-	 *                      retail/point-of-sale use cases. Defaults to FeePlan::KIND_GENERAL
-	 * @param string|int[] $installmentsCounts Only include fee plans that match the given installments counts, or use
-	 *                                         the string "all" (default) to get all available fee plans
-	 * @param bool $includeDeferred Include deferred fee plans (i.e. Pay Later plans) in the response
-	 * @return FeePlan[] An array of available fee plans (some might be disabled, check FeePlan->allowed for each)
-	 * @throws RequestError
-	 */
-	public function feePlans($kind = FeePlan::KIND_GENERAL, $installmentsCounts = "all", $includeDeferred = false)
-	{
-		if (is_array($installmentsCounts)) {
-			$only = implode(",", $installmentsCounts);
-		} else {
-			$only = $installmentsCounts;
-		}
+    /**
+     * @param $kind string  Either FeePlan::KIND_GENERAL or FeePlan::KIND_POS. The former is applied to online payments,
+     *                      while the latter will be used when creating a Payment with origin=pos_* for
+     *                      retail/point-of-sale use cases. Defaults to FeePlan::KIND_GENERAL
+     * @param string|int[] $installmentsCounts Only include fee plans that match the given installments counts, or use
+     *                                         the string "all" (default) to get all available fee plans
+     * @param bool $includeDeferred Include deferred fee plans (i.e. Pay Later plans) in the response
+     * @return FeePlan[] An array of available fee plans (some might be disabled, check FeePlan->allowed for each)
+     * @throws RequestError
+     */
+    public function feePlans($kind = FeePlan::KIND_GENERAL, $installmentsCounts = "all", $includeDeferred = false)
+    {
+        if (is_array($installmentsCounts)) {
+            $only = implode(",", $installmentsCounts);
+        } else {
+            $only = $installmentsCounts;
+        }
 
-		$res = $this->request(self::ME_PATH . "/fee-plans")->setQueryParams(array(
-			"kind" => $kind,
-			"only" => $only,
-			"deferred" => $includeDeferred ? "true" : "false" // Avoid conversion to "0"/"1" our API doesn't recognize
-		))->get();
+        $res = $this->request(self::ME_PATH . "/fee-plans")->setQueryParams(array(
+            "kind" => $kind,
+            "only" => $only,
+            "deferred" => $includeDeferred ? "true" : "false" // Avoid conversion to "0"/"1" our API doesn't recognize
+        ))->get();
 
-		if ($res->isError()) {
-			throw new RequestError($res->errorMessage, null, $res);
-		}
+        if ($res->isError()) {
+            throw new RequestError($res->errorMessage, null, $res);
+        }
 
-		return array_map(function ($val) {
-			return new FeePlan($val);
-		}, $res->json);
-	}
+        return array_map(function ($val) {
+            return new FeePlan($val);
+        }, $res->json);
+    }
 
-	/**
-	 * @param string $url The URL to send to Alma for integrations configuration
-	 * @throws RequestException
-	 * @throws RequestError
-	 */
-	public function sendIntegrationsConfigurationsUrl($url)
-	{
-		$res = $this->request(self::ME_PATH . "/integrations/configurations")->setRequestBody(array(
-			"endpoint_url" => $url
-		))->post();
+    /**
+     * @param string $url The URL to send to Alma for integrations configuration
+     * @throws RequestException
+     * @throws RequestError
+     */
+    public function sendIntegrationsConfigurationsUrl($url)
+    {
+        $res = $this->request(self::ME_PATH . "/configuration")->setRequestBody(array(
+            "endpoint_url" => $url
+        ))->post();
 
-		if ($res->isError()) {
-			throw new RequestException($res->errorMessage, null, $res);
-		}
-	}
+        if ($res->isError()) {
+            throw new RequestException($res->errorMessage, null, $res);
+        }
+    }
 }

--- a/src/Entities/MerchantData/CmsFeatures.php
+++ b/src/Entities/MerchantData/CmsFeatures.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Alma\API\Entities\MerchantData;
+
+class CmsFeatures
+{
+	/**
+	 * @var bool | null
+	 */
+	private $almaEnabled;
+
+	/**
+	 * @var bool | null
+	 */
+	private $widgetCartActivated;
+
+	/**
+	 * @var bool | null
+	 */
+	private $widgetProductActivated;
+
+	/**
+	 * @var mixed
+	 */
+	private $usedFeePlans;
+
+	/**
+	 * @var int | null
+	 */
+	private $paymentMethodPosition;
+
+	/**
+	 * @var bool | null
+	 */
+	private $inPageActivated;
+
+	/**
+	 * @var bool | null
+	 */
+	private $logActivated;
+
+	/**
+	 * @var string[]
+	 */
+	private $excludedCategories;
+
+	/**
+	 * @var bool | null
+	 */
+	private $excludedCategoriesActivated;
+
+	/**
+	 * @var array<array{name: string}>
+	 */
+	private $specificFeatures;
+
+	/**
+	 * @var string[]
+	 */
+	private $countryRestriction;
+
+	/**
+	 * @var bool | null
+	 */
+	private $isMultisite;
+
+	/**
+	 * @var bool | null
+	 */
+	private $customWidgetCss;
+
+	/**
+	 * CmsFeatures constructor.
+	 * @param array $cmsFeaturesDataArray
+	 */
+	public function __construct($cmsFeaturesDataArray)
+	{
+		// Ensure values are properly initialized
+		$this->almaEnabled = isset($cmsFeaturesDataArray['alma_enabled']) ? $cmsFeaturesDataArray['alma_enabled'] : null;
+		$this->widgetCartActivated = isset($cmsFeaturesDataArray['widget_cart_activated']) ? $cmsFeaturesDataArray['widget_cart_activated'] : null;
+		$this->widgetProductActivated = isset($cmsFeaturesDataArray['widget_product_activated']) ? $cmsFeaturesDataArray['widget_product_activated'] : null;
+		$this->usedFeePlans = $cmsFeaturesDataArray['used_fee_plans'] ?: '';
+		$this->inPageActivated = isset($cmsFeaturesDataArray['in_page_activated']) ? $cmsFeaturesDataArray['in_page_activated'] : null;
+		$this->logActivated = isset($cmsFeaturesDataArray['log_activated']) ? $cmsFeaturesDataArray['log_activated'] : null;
+		$this->excludedCategories = $cmsFeaturesDataArray['excluded_categories'] ?: [];
+		$this->excludedCategoriesActivated = isset($cmsFeaturesDataArray['excluded_categories_activated']) ?
+			$cmsFeaturesDataArray['excluded_categories_activated'] : null;
+		$this->paymentMethodPosition = $cmsFeaturesDataArray['payment_method_position'] ?: null;
+		$this->specificFeatures = $cmsFeaturesDataArray['specific_features'] ?: [];
+		$this->countryRestriction = $cmsFeaturesDataArray['country_restriction'] ?: [];
+		$this->isMultisite = isset($cmsFeaturesDataArray['is_multisite']) ? $cmsFeaturesDataArray['is_multisite'] : null;
+		$this->customWidgetCss = isset($cmsFeaturesDataArray['custom_widget_css']) ? $cmsFeaturesDataArray['custom_widget_css'] : null;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getProperties()
+	{
+		// Use array_filter with ARRAY_FILTER_USE_BOTH to remove null or empty values
+		return array_filter([
+			'alma_enabled' => $this->almaEnabled,
+			'widget_cart_activated' => $this->widgetCartActivated,
+			'widget_product_activated' => $this->widgetProductActivated,
+			'used_fee_plans' => $this->usedFeePlans,
+			'in_page_activated' => $this->inPageActivated,
+			'log_activated' => $this->logActivated,
+			'excluded_categories' => $this->excludedCategories,
+			'excluded_categories_activated' => $this->excludedCategoriesActivated,
+			'payment_method_position' => $this->paymentMethodPosition,
+			'specific_features' => $this->specificFeatures,
+			'country_restriction' => $this->countryRestriction,
+			'is_multisite' => $this->isMultisite,
+			'custom_widget_css' => $this->customWidgetCss,
+		], function($value) {
+			// Keep only values that are not null and not empty
+			return !is_null($value) && $value !== '';
+		});
+	}
+}

--- a/src/Entities/MerchantData/CmsFeatures.php
+++ b/src/Entities/MerchantData/CmsFeatures.php
@@ -4,117 +4,118 @@ namespace Alma\API\Entities\MerchantData;
 
 class CmsFeatures
 {
-	/**
-	 * @var bool | null
-	 */
-	private $almaEnabled;
+    /**
+     * @var bool | null
+     */
+    private $almaEnabled;
 
-	/**
-	 * @var bool | null
-	 */
-	private $widgetCartActivated;
+    /**
+     * @var bool | null
+     */
+    private $widgetCartActivated;
 
-	/**
-	 * @var bool | null
-	 */
-	private $widgetProductActivated;
+    /**
+     * @var bool | null
+     */
+    private $widgetProductActivated;
 
-	/**
-	 * @var mixed
-	 */
-	private $usedFeePlans;
+    /**
+     * @var array
+     */
+    private $usedFeePlans;
 
-	/**
-	 * @var int | null
-	 */
-	private $paymentMethodPosition;
+    /**
+     * @var int | null
+     */
+    private $paymentMethodPosition;
 
-	/**
-	 * @var bool | null
-	 */
-	private $inPageActivated;
+    /**
+     * @var bool | null
+     */
+    private $inPageActivated;
 
-	/**
-	 * @var bool | null
-	 */
-	private $logActivated;
+    /**
+     * @var bool | null
+     */
+    private $logActivated;
 
-	/**
-	 * @var string[]
-	 */
-	private $excludedCategories;
+    /**
+     * @var string[]
+     */
+    private $excludedCategories;
 
-	/**
-	 * @var bool | null
-	 */
-	private $excludedCategoriesActivated;
+    /**
+     * @var bool | null
+     */
+    private $excludedCategoriesActivated;
 
-	/**
-	 * @var array<array{name: string}>
-	 */
-	private $specificFeatures;
+    /**
+     * @var array<array{name: string}>
+     */
+    private $specificFeatures;
 
-	/**
-	 * @var string[]
-	 */
-	private $countryRestriction;
+    /**
+     * @var string[]
+     */
+    private $countryRestriction;
 
-	/**
-	 * @var bool | null
-	 */
-	private $isMultisite;
+    /**
+     * @var bool | null
+     */
+    private $isMultisite;
 
-	/**
-	 * @var bool | null
-	 */
-	private $customWidgetCss;
+    /**
+     * @var bool | null
+     */
+    private $customWidgetCss;
 
-	/**
-	 * CmsFeatures constructor.
-	 * @param array $cmsFeaturesDataArray
-	 */
-	public function __construct($cmsFeaturesDataArray)
-	{
-		// Ensure values are properly initialized
-		$this->almaEnabled = isset($cmsFeaturesDataArray['alma_enabled']) ? $cmsFeaturesDataArray['alma_enabled'] : null;
-		$this->widgetCartActivated = isset($cmsFeaturesDataArray['widget_cart_activated']) ? $cmsFeaturesDataArray['widget_cart_activated'] : null;
-		$this->widgetProductActivated = isset($cmsFeaturesDataArray['widget_product_activated']) ? $cmsFeaturesDataArray['widget_product_activated'] : null;
-		$this->usedFeePlans = isset($cmsFeaturesDataArray['used_fee_plans']) ? $cmsFeaturesDataArray['used_fee_plans'] : '';
-		$this->inPageActivated = isset($cmsFeaturesDataArray['in_page_activated']) ? $cmsFeaturesDataArray['in_page_activated'] : null;
-		$this->logActivated = isset($cmsFeaturesDataArray['log_activated']) ? $cmsFeaturesDataArray['log_activated'] : null;
-		$this->excludedCategories = isset($cmsFeaturesDataArray['excluded_categories']) ? $cmsFeaturesDataArray['excluded_categories'] : [];
-		$this->excludedCategoriesActivated = isset($cmsFeaturesDataArray['excluded_categories_activated']) ?
-			$cmsFeaturesDataArray['excluded_categories_activated'] : null;
-		$this->paymentMethodPosition = isset($cmsFeaturesDataArray['payment_method_position']) ? $cmsFeaturesDataArray['payment_method_position'] : null;
-		$this->specificFeatures = isset($cmsFeaturesDataArray['specific_features']) ? $cmsFeaturesDataArray['specific_features'] : [];
-		$this->countryRestriction = isset($cmsFeaturesDataArray['country_restriction']) ? $cmsFeaturesDataArray['country_restriction'] : [];
-		$this->isMultisite = isset($cmsFeaturesDataArray['is_multisite']) ? $cmsFeaturesDataArray['is_multisite'] : null;
-		$this->customWidgetCss = isset($cmsFeaturesDataArray['custom_widget_css']) ? $cmsFeaturesDataArray['custom_widget_css'] : null;
-	}
+    /**
+     * CmsFeatures constructor.
+     * @param array $cmsFeaturesDataArray
+     */
+    public function __construct($cmsFeaturesDataArray)
+    {
+        // Ensure values are properly initialized
+        $this->almaEnabled = isset($cmsFeaturesDataArray['alma_enabled']) ? $cmsFeaturesDataArray['alma_enabled'] : null;
+        $this->widgetCartActivated = isset($cmsFeaturesDataArray['widget_cart_activated']) ? $cmsFeaturesDataArray['widget_cart_activated'] : null;
+        $this->widgetProductActivated = isset($cmsFeaturesDataArray['widget_product_activated']) ? $cmsFeaturesDataArray['widget_product_activated'] : null;
+        $this->usedFeePlans = isset($cmsFeaturesDataArray['used_fee_plans']) ? $cmsFeaturesDataArray['used_fee_plans'] : [];
+        $this->inPageActivated = isset($cmsFeaturesDataArray['in_page_activated']) ? $cmsFeaturesDataArray['in_page_activated'] : null;
+        $this->logActivated = isset($cmsFeaturesDataArray['log_activated']) ? $cmsFeaturesDataArray['log_activated'] : null;
+        $this->excludedCategories = isset($cmsFeaturesDataArray['excluded_categories']) ? $cmsFeaturesDataArray['excluded_categories'] : [];
+        $this->excludedCategoriesActivated = isset($cmsFeaturesDataArray['excluded_categories_activated']) ?
+            $cmsFeaturesDataArray['excluded_categories_activated'] : null;
+        $this->paymentMethodPosition = isset($cmsFeaturesDataArray['payment_method_position']) ? $cmsFeaturesDataArray['payment_method_position'] : null;
+        $this->specificFeatures = isset($cmsFeaturesDataArray['specific_features']) ? $cmsFeaturesDataArray['specific_features'] : [];
+        $this->countryRestriction = isset($cmsFeaturesDataArray['country_restriction']) ? $cmsFeaturesDataArray['country_restriction'] : [];
+        $this->isMultisite = isset($cmsFeaturesDataArray['is_multisite']) ? $cmsFeaturesDataArray['is_multisite'] : null;
+        $this->customWidgetCss = isset($cmsFeaturesDataArray['custom_widget_css']) ? $cmsFeaturesDataArray['custom_widget_css'] : null;
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getProperties()
-	{
-		// Use array_filter with ARRAY_FILTER_USE_BOTH to remove null or empty values
-		return array_filter([
-			'alma_enabled' => $this->almaEnabled,
-			'widget_cart_activated' => $this->widgetCartActivated,
-			'widget_product_activated' => $this->widgetProductActivated,
-			'used_fee_plans' => $this->usedFeePlans,
-			'in_page_activated' => $this->inPageActivated,
-			'log_activated' => $this->logActivated,
-			'excluded_categories' => $this->excludedCategories,
-			'excluded_categories_activated' => $this->excludedCategoriesActivated,
-			'payment_method_position' => $this->paymentMethodPosition,
-			'specific_features' => $this->specificFeatures,
-			'country_restriction' => $this->countryRestriction,
-			'is_multisite' => $this->isMultisite,
-			'custom_widget_css' => $this->customWidgetCss,
-		], function($value) {
-			// Keep only values that are not null and not empty
-			return !is_null($value) && $value !== '';
-		});
-	}
+    /**
+     * @return array
+     */
+    public function getProperties()
+    {
+        // Use array_filter with ARRAY_FILTER_USE_BOTH to remove null or empty values
+        return array_filter([
+            'alma_enabled' => $this->almaEnabled,
+            'widget_cart_activated' => $this->widgetCartActivated,
+            'widget_product_activated' => $this->widgetProductActivated,
+            'used_fee_plans' => $this->usedFeePlans,
+            'in_page_activated' => $this->inPageActivated,
+            'log_activated' => $this->logActivated,
+            'excluded_categories' => $this->excludedCategories,
+            'excluded_categories_activated' => $this->excludedCategoriesActivated,
+            'payment_method_position' => $this->paymentMethodPosition,
+            'specific_features' => $this->specificFeatures,
+            'country_restriction' => $this->countryRestriction,
+            'is_multisite' => $this->isMultisite,
+            'custom_widget_css' => $this->customWidgetCss,
+        ], function ($value) {
+            // Keep only values that are not null and not empty
+            // But keep false or 0 values
+            return !is_null($value) && $value !== '';
+        });
+    }
 }

--- a/src/Entities/MerchantData/CmsFeatures.php
+++ b/src/Entities/MerchantData/CmsFeatures.php
@@ -79,15 +79,15 @@ class CmsFeatures
 		$this->almaEnabled = isset($cmsFeaturesDataArray['alma_enabled']) ? $cmsFeaturesDataArray['alma_enabled'] : null;
 		$this->widgetCartActivated = isset($cmsFeaturesDataArray['widget_cart_activated']) ? $cmsFeaturesDataArray['widget_cart_activated'] : null;
 		$this->widgetProductActivated = isset($cmsFeaturesDataArray['widget_product_activated']) ? $cmsFeaturesDataArray['widget_product_activated'] : null;
-		$this->usedFeePlans = $cmsFeaturesDataArray['used_fee_plans'] ?: '';
+		$this->usedFeePlans = isset($cmsFeaturesDataArray['used_fee_plans']) ? $cmsFeaturesDataArray['used_fee_plans'] : '';
 		$this->inPageActivated = isset($cmsFeaturesDataArray['in_page_activated']) ? $cmsFeaturesDataArray['in_page_activated'] : null;
 		$this->logActivated = isset($cmsFeaturesDataArray['log_activated']) ? $cmsFeaturesDataArray['log_activated'] : null;
-		$this->excludedCategories = $cmsFeaturesDataArray['excluded_categories'] ?: [];
+		$this->excludedCategories = isset($cmsFeaturesDataArray['excluded_categories']) ? $cmsFeaturesDataArray['excluded_categories'] : [];
 		$this->excludedCategoriesActivated = isset($cmsFeaturesDataArray['excluded_categories_activated']) ?
 			$cmsFeaturesDataArray['excluded_categories_activated'] : null;
-		$this->paymentMethodPosition = $cmsFeaturesDataArray['payment_method_position'] ?: null;
-		$this->specificFeatures = $cmsFeaturesDataArray['specific_features'] ?: [];
-		$this->countryRestriction = $cmsFeaturesDataArray['country_restriction'] ?: [];
+		$this->paymentMethodPosition = isset($cmsFeaturesDataArray['payment_method_position']) ? $cmsFeaturesDataArray['payment_method_position'] : null;
+		$this->specificFeatures = isset($cmsFeaturesDataArray['specific_features']) ? $cmsFeaturesDataArray['specific_features'] : [];
+		$this->countryRestriction = isset($cmsFeaturesDataArray['country_restriction']) ? $cmsFeaturesDataArray['country_restriction'] : [];
 		$this->isMultisite = isset($cmsFeaturesDataArray['is_multisite']) ? $cmsFeaturesDataArray['is_multisite'] : null;
 		$this->customWidgetCss = isset($cmsFeaturesDataArray['custom_widget_css']) ? $cmsFeaturesDataArray['custom_widget_css'] : null;
 	}

--- a/src/Entities/MerchantData/CmsInfo.php
+++ b/src/Entities/MerchantData/CmsInfo.php
@@ -5,12 +5,12 @@ namespace Alma\API\Entities\MerchantData;
 class CmsInfo
 {
     /**
-     * @var string|null
+     * @var string
      */
     private $cmsName;
 
     /**
-     * @var string|null
+     * @var string
      */
     private $cmsVersion;
 
@@ -25,27 +25,27 @@ class CmsInfo
     private $themes;
 
     /**
-     * @var string|null
+     * @var string
      */
     private $languageName;
 
     /**
-     * @var string|null
+     * @var string
      */
     private $languageVersion;
 
     /**
-     * @var string|null
+     * @var string
      */
     private $almaPluginVersion;
 
     /**
-     * @var string|null
+     * @var string
      */
     private $almaSdkVersion;
 
     /**
-     * @var string|null
+     * @var string
      */
     private $almaSdkName;
 
@@ -56,15 +56,15 @@ class CmsInfo
     public function __construct($cmsInfoDataArray)
     {
         // Initialize values or set them to null if not available
-        $this->cmsName = isset($cmsInfoDataArray['cms_name']) ? $cmsInfoDataArray['cms_name'] : null;
-        $this->cmsVersion = isset($cmsInfoDataArray['cms_version']) ? $cmsInfoDataArray['cms_version'] : null;
+        $this->cmsName = isset($cmsInfoDataArray['cms_name']) ? $cmsInfoDataArray['cms_name'] : '';
+        $this->cmsVersion = isset($cmsInfoDataArray['cms_version']) ? $cmsInfoDataArray['cms_version'] : '';
         $this->thirdPartiesPlugins = isset($cmsInfoDataArray['third_parties_plugins']) ? $cmsInfoDataArray['third_parties_plugins'] : [];
         $this->themes = isset($cmsInfoDataArray['themes']) ? $cmsInfoDataArray['themes'] : [];
-        $this->languageName = isset($cmsInfoDataArray['language_name']) ? $cmsInfoDataArray['language_name'] : null;
-        $this->languageVersion = isset($cmsInfoDataArray['language_version']) ? $cmsInfoDataArray['language_version'] : null;
-        $this->almaPluginVersion = isset($cmsInfoDataArray['alma_plugin_version']) ? $cmsInfoDataArray['alma_plugin_version'] : null;
-        $this->almaSdkVersion = isset($cmsInfoDataArray['alma_sdk_version']) ? $cmsInfoDataArray['alma_sdk_version'] : null;
-        $this->almaSdkName = isset($cmsInfoDataArray['alma_sdk_name']) ? $cmsInfoDataArray['alma_sdk_name'] : null;
+        $this->languageName = isset($cmsInfoDataArray['language_name']) ? $cmsInfoDataArray['language_name'] : '';
+        $this->languageVersion = isset($cmsInfoDataArray['language_version']) ? $cmsInfoDataArray['language_version'] : '';
+        $this->almaPluginVersion = isset($cmsInfoDataArray['alma_plugin_version']) ? $cmsInfoDataArray['alma_plugin_version'] : '';
+        $this->almaSdkVersion = isset($cmsInfoDataArray['alma_sdk_version']) ? $cmsInfoDataArray['alma_sdk_version'] : '';
+        $this->almaSdkName = isset($cmsInfoDataArray['alma_sdk_name']) ? $cmsInfoDataArray['alma_sdk_name'] : '';
     }
 
     /**

--- a/src/Entities/MerchantData/CmsInfo.php
+++ b/src/Entities/MerchantData/CmsInfo.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Alma\API\Entities\MerchantData;
+
+class CmsInfo
+{
+	/**
+	 * @var string|null
+	 */
+	private $cmsName;
+
+	/**
+	 * @var string|null
+	 */
+	private $cmsVersion;
+
+	/**
+	 * @var array<array{name: string, version: string}>
+	 */
+	private $thirdPartiesPlugins;
+
+	/**
+	 * @var array<array{name: string, version: string}>
+	 */
+	private $themes;
+
+	/**
+	 * @var string|null
+	 */
+	private $languageName;
+
+	/**
+	 * @var string|null
+	 */
+	private $languageVersion;
+
+	/**
+	 * @var string|null
+	 */
+	private $almaPluginVersion;
+
+	/**
+	 * @var string|null
+	 */
+	private $almaSdkVersion;
+
+	/**
+	 * @var string|null
+	 */
+	private $almaSdkName;
+
+	/**
+	 * CmsInfo constructor.
+	 * @param array $cmsInfoDataArray
+	 */
+	public function __construct($cmsInfoDataArray)
+	{
+		// Initialize values or set them to null if not available
+		$this->cmsName = $cmsInfoDataArray['cms_name'] ?: null;
+		$this->cmsVersion = $cmsInfoDataArray['cms_version'] ?: null;
+		$this->thirdPartiesPlugins = $cmsInfoDataArray['third_parties_plugins'] ?: [];
+		$this->themes = $cmsInfoDataArray['themes'] ?: [];
+		$this->languageName = $cmsInfoDataArray['language_name'] ?: null;
+		$this->languageVersion = $cmsInfoDataArray['language_version'] ?: null;
+		$this->almaPluginVersion = $cmsInfoDataArray['alma_plugin_version'] ?: null;
+		$this->almaSdkVersion = $cmsInfoDataArray['alma_sdk_version'] ?: null;
+		$this->almaSdkName = $cmsInfoDataArray['alma_sdk_name'] ?: null;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getProperties()
+	{
+		// Use array_filter with ARRAY_FILTER_USE_BOTH to remove null or empty values
+		return array_filter([
+			'cms_name' => $this->cmsName,
+			'cms_version' => $this->cmsVersion,
+			'third_parties_plugins' => $this->thirdPartiesPlugins,
+			'themes' => $this->themes,
+			'language_name' => $this->languageName,
+			'language_version' => $this->languageVersion,
+			'alma_plugin_version' => $this->almaPluginVersion,
+			'alma_sdk_version' => $this->almaSdkVersion,
+			'alma_sdk_name' => $this->almaSdkName,
+		], function($value) {
+			// Keep only values that are not null and not empty
+			return !is_null($value) && $value !== '';
+		});
+	}
+}

--- a/src/Entities/MerchantData/CmsInfo.php
+++ b/src/Entities/MerchantData/CmsInfo.php
@@ -4,88 +4,89 @@ namespace Alma\API\Entities\MerchantData;
 
 class CmsInfo
 {
-	/**
-	 * @var string|null
-	 */
-	private $cmsName;
+    /**
+     * @var string|null
+     */
+    private $cmsName;
 
-	/**
-	 * @var string|null
-	 */
-	private $cmsVersion;
+    /**
+     * @var string|null
+     */
+    private $cmsVersion;
 
-	/**
-	 * @var array<array{name: string, version: string}>
-	 */
-	private $thirdPartiesPlugins;
+    /**
+     * @var array<array{name: string, version: string}>
+     */
+    private $thirdPartiesPlugins;
 
-	/**
-	 * @var array<array{name: string, version: string}>
-	 */
-	private $themes;
+    /**
+     * @var array<array{name: string, version: string}>
+     */
+    private $themes;
 
-	/**
-	 * @var string|null
-	 */
-	private $languageName;
+    /**
+     * @var string|null
+     */
+    private $languageName;
 
-	/**
-	 * @var string|null
-	 */
-	private $languageVersion;
+    /**
+     * @var string|null
+     */
+    private $languageVersion;
 
-	/**
-	 * @var string|null
-	 */
-	private $almaPluginVersion;
+    /**
+     * @var string|null
+     */
+    private $almaPluginVersion;
 
-	/**
-	 * @var string|null
-	 */
-	private $almaSdkVersion;
+    /**
+     * @var string|null
+     */
+    private $almaSdkVersion;
 
-	/**
-	 * @var string|null
-	 */
-	private $almaSdkName;
+    /**
+     * @var string|null
+     */
+    private $almaSdkName;
 
-	/**
-	 * CmsInfo constructor.
-	 * @param array $cmsInfoDataArray
-	 */
-	public function __construct($cmsInfoDataArray)
-	{
-		// Initialize values or set them to null if not available
-		$this->cmsName = isset($cmsInfoDataArray['cms_name']) ? $cmsInfoDataArray['cms_name'] : null;
-		$this->cmsVersion = isset($cmsInfoDataArray['cms_version']) ? $cmsInfoDataArray['cms_version'] : null;
-		$this->thirdPartiesPlugins = isset($cmsInfoDataArray['third_parties_plugins']) ? $cmsInfoDataArray['third_parties_plugins'] : [];
-		$this->themes = isset($cmsInfoDataArray['themes']) ? $cmsInfoDataArray['themes'] : [];
-		$this->languageName = isset($cmsInfoDataArray['language_name']) ? $cmsInfoDataArray['language_name'] : null;
-		$this->languageVersion = isset($cmsInfoDataArray['language_version']) ? $cmsInfoDataArray['language_version'] : null;
-		$this->almaPluginVersion = isset($cmsInfoDataArray['alma_plugin_version']) ? $cmsInfoDataArray['alma_plugin_version'] : null;
-		$this->almaSdkVersion = isset($cmsInfoDataArray['alma_sdk_version']) ? $cmsInfoDataArray['alma_sdk_version'] : null;
-		$this->almaSdkName = isset($cmsInfoDataArray['alma_sdk_name']) ? $cmsInfoDataArray['alma_sdk_name'] : null;
-	}
+    /**
+     * CmsInfo constructor.
+     * @param array $cmsInfoDataArray
+     */
+    public function __construct($cmsInfoDataArray)
+    {
+        // Initialize values or set them to null if not available
+        $this->cmsName = isset($cmsInfoDataArray['cms_name']) ? $cmsInfoDataArray['cms_name'] : null;
+        $this->cmsVersion = isset($cmsInfoDataArray['cms_version']) ? $cmsInfoDataArray['cms_version'] : null;
+        $this->thirdPartiesPlugins = isset($cmsInfoDataArray['third_parties_plugins']) ? $cmsInfoDataArray['third_parties_plugins'] : [];
+        $this->themes = isset($cmsInfoDataArray['themes']) ? $cmsInfoDataArray['themes'] : [];
+        $this->languageName = isset($cmsInfoDataArray['language_name']) ? $cmsInfoDataArray['language_name'] : null;
+        $this->languageVersion = isset($cmsInfoDataArray['language_version']) ? $cmsInfoDataArray['language_version'] : null;
+        $this->almaPluginVersion = isset($cmsInfoDataArray['alma_plugin_version']) ? $cmsInfoDataArray['alma_plugin_version'] : null;
+        $this->almaSdkVersion = isset($cmsInfoDataArray['alma_sdk_version']) ? $cmsInfoDataArray['alma_sdk_version'] : null;
+        $this->almaSdkName = isset($cmsInfoDataArray['alma_sdk_name']) ? $cmsInfoDataArray['alma_sdk_name'] : null;
+    }
 
-	/**
-	 * @return array
-	 */
-	public function getProperties()
-	{
-		// Use array_filter with ARRAY_FILTER_USE_BOTH to remove null or empty values
-		return array_filter([
-			'cms_name' => $this->cmsName,
-			'cms_version' => $this->cmsVersion,
-			'third_parties_plugins' => $this->thirdPartiesPlugins,
-			'themes' => $this->themes,
-			'language_name' => $this->languageName,
-			'language_version' => $this->languageVersion,
-			'alma_plugin_version' => $this->almaPluginVersion,
-			'alma_sdk_version' => $this->almaSdkVersion,
-			'alma_sdk_name' => $this->almaSdkName,
-		], function($value) {
-			// Keep only values that are not null and not empty
-			return !is_null($value) && $value !== '';
-		});
-	}
+    /**
+     * @return array
+     */
+    public function getProperties()
+    {
+        // Use array_filter with ARRAY_FILTER_USE_BOTH to remove null or empty values
+        return array_filter([
+            'cms_name' => $this->cmsName,
+            'cms_version' => $this->cmsVersion,
+            'third_parties_plugins' => $this->thirdPartiesPlugins,
+            'themes' => $this->themes,
+            'language_name' => $this->languageName,
+            'language_version' => $this->languageVersion,
+            'alma_plugin_version' => $this->almaPluginVersion,
+            'alma_sdk_version' => $this->almaSdkVersion,
+            'alma_sdk_name' => $this->almaSdkName,
+        ], function ($value) {
+            // Keep only values that are not null and not empty
+            // But keep false or 0 values
+            return !is_null($value) && $value !== '';
+        });
+    }
 }

--- a/src/Entities/MerchantData/CmsInfo.php
+++ b/src/Entities/MerchantData/CmsInfo.php
@@ -56,15 +56,15 @@ class CmsInfo
 	public function __construct($cmsInfoDataArray)
 	{
 		// Initialize values or set them to null if not available
-		$this->cmsName = $cmsInfoDataArray['cms_name'] ?: null;
-		$this->cmsVersion = $cmsInfoDataArray['cms_version'] ?: null;
-		$this->thirdPartiesPlugins = $cmsInfoDataArray['third_parties_plugins'] ?: [];
-		$this->themes = $cmsInfoDataArray['themes'] ?: [];
-		$this->languageName = $cmsInfoDataArray['language_name'] ?: null;
-		$this->languageVersion = $cmsInfoDataArray['language_version'] ?: null;
-		$this->almaPluginVersion = $cmsInfoDataArray['alma_plugin_version'] ?: null;
-		$this->almaSdkVersion = $cmsInfoDataArray['alma_sdk_version'] ?: null;
-		$this->almaSdkName = $cmsInfoDataArray['alma_sdk_name'] ?: null;
+		$this->cmsName = isset($cmsInfoDataArray['cms_name']) ? $cmsInfoDataArray['cms_name'] : null;
+		$this->cmsVersion = isset($cmsInfoDataArray['cms_version']) ? $cmsInfoDataArray['cms_version'] : null;
+		$this->thirdPartiesPlugins = isset($cmsInfoDataArray['third_parties_plugins']) ? $cmsInfoDataArray['third_parties_plugins'] : [];
+		$this->themes = isset($cmsInfoDataArray['themes']) ? $cmsInfoDataArray['themes'] : [];
+		$this->languageName = isset($cmsInfoDataArray['language_name']) ? $cmsInfoDataArray['language_name'] : null;
+		$this->languageVersion = isset($cmsInfoDataArray['language_version']) ? $cmsInfoDataArray['language_version'] : null;
+		$this->almaPluginVersion = isset($cmsInfoDataArray['alma_plugin_version']) ? $cmsInfoDataArray['alma_plugin_version'] : null;
+		$this->almaSdkVersion = isset($cmsInfoDataArray['alma_sdk_version']) ? $cmsInfoDataArray['alma_sdk_version'] : null;
+		$this->almaSdkName = isset($cmsInfoDataArray['alma_sdk_name']) ? $cmsInfoDataArray['alma_sdk_name'] : null;
 	}
 
 	/**

--- a/src/Lib/PayloadFormatter.php
+++ b/src/Lib/PayloadFormatter.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Alma\API\Lib;
+
+use Alma\API\Entities\MerchantData\CmsFeatures;
+use Alma\API\Entities\MerchantData\CmsInfo;
+
+class PayloadFormatter
+{
+	/**
+	 * @param CmsInfo $cmsInfo
+	 * @param CmsFeatures $cmsFeatures
+	 * @return string
+	 */
+	public static function formatIntegrationConfigurationPayload(CmsInfo $cmsInfo, CmsFeatures $cmsFeatures)
+	{
+		$payload = [
+			"cms_info" => $cmsInfo->getProperties(),
+			"cms_features" => $cmsFeatures->getProperties(),
+		];
+
+		return json_encode($payload);
+	}
+
+}

--- a/src/Lib/PayloadFormatter.php
+++ b/src/Lib/PayloadFormatter.php
@@ -10,16 +10,14 @@ class PayloadFormatter
 	/**
 	 * @param CmsInfo $cmsInfo
 	 * @param CmsFeatures $cmsFeatures
-	 * @return string
+	 * @return array
 	 */
 	public function formatConfigurationPayload(CmsInfo $cmsInfo, CmsFeatures $cmsFeatures)
 	{
-		$payload = [
+		return [
 			"cms_info" => $cmsInfo->getProperties(),
 			"cms_features" => $cmsFeatures->getProperties(),
 		];
-
-		return json_encode($payload);
 	}
 
 }

--- a/src/Lib/PayloadFormatter.php
+++ b/src/Lib/PayloadFormatter.php
@@ -12,7 +12,7 @@ class PayloadFormatter
 	 * @param CmsFeatures $cmsFeatures
 	 * @return string
 	 */
-	public static function formatIntegrationConfigurationPayload(CmsInfo $cmsInfo, CmsFeatures $cmsFeatures)
+	public function formatConfigurationPayload(CmsInfo $cmsInfo, CmsFeatures $cmsFeatures)
 	{
 		$payload = [
 			"cms_info" => $cmsInfo->getProperties(),

--- a/tests/Unit/Endpoints/MerchantsTest.php
+++ b/tests/Unit/Endpoints/MerchantsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Unit\Endpoints;
+
+use Alma\API\Endpoints\Merchants;
+use Alma\API\Exceptions\RequestException;
+use Alma\API\Request;
+use Alma\API\Response;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class MerchantsTest extends TestCase
+{
+	public function setUp(): void
+	{
+		$this->merchantEndpoint = Mockery::mock(Merchants::class)->makePartial();
+		$this->responseMock = Mockery::mock(Response::class);
+		$this->requestObject = Mockery::mock(Request::class);
+	}
+
+	public function tearDown(): void
+	{
+		$this->merchantEndpoint = null;
+		$this->responseMock = null;
+		$this->requestObject = null;
+		Mockery::close();
+	}
+
+	public function testSendIntegrationsConfigurationsUrlIsOk(){
+		$this->responseMock->shouldReceive('isError')->once()->andReturn(false);
+		$this->requestObject->shouldReceive('setRequestBody')
+			->with(['endpoint_url' => 'https://www.example.com/integrations/configurations'])
+			->andReturn($this->requestObject);
+
+		$this->merchantEndpoint->shouldReceive('request')
+			->with(Merchants::ME_PATH . "/integrations/configurations")
+			->once()
+			->andReturn($this->requestObject);
+		$this->requestObject->shouldReceive('post')->once()->andReturn($this->responseMock);
+
+		$url = "https://www.example.com/integrations/configurations";
+		$this->assertNull($this->merchantEndpoint->sendIntegrationsConfigurationsUrl($url));
+	}
+
+	public function testSendIntegrationsConfigurationsUrlThrowRequestException(){
+		$this->responseMock->shouldReceive('isError')->once()->andReturn(true);
+		$this->requestObject->shouldReceive('setRequestBody')
+			->with(['endpoint_url' => 'https://www.example.com/integrations/configurations'])
+			->andReturn($this->requestObject);
+
+		$this->merchantEndpoint->shouldReceive('request')
+			->with(Merchants::ME_PATH . "/integrations/configurations")
+			->once()
+			->andReturn($this->requestObject);
+		$this->requestObject->shouldReceive('post')->once()->andReturn($this->responseMock);
+
+		$url = "https://www.example.com/integrations/configurations";
+		$this->expectException(RequestException::class);
+		$this->merchantEndpoint->sendIntegrationsConfigurationsUrl($url);
+
+	}
+}

--- a/tests/Unit/Endpoints/MerchantsTest.php
+++ b/tests/Unit/Endpoints/MerchantsTest.php
@@ -35,7 +35,7 @@ class MerchantsTest extends TestCase
 			->andReturn($this->requestObject);
 
 		$this->merchantEndpoint->shouldReceive('request')
-			->with(Merchants::ME_PATH . "/integrations/configurations")
+			->with(Merchants::ME_PATH . "/configuration")
 			->once()
 			->andReturn($this->requestObject);
 		$this->requestObject->shouldReceive('post')->once()->andReturn($this->responseMock);
@@ -51,7 +51,7 @@ class MerchantsTest extends TestCase
 			->andReturn($this->requestObject);
 
 		$this->merchantEndpoint->shouldReceive('request')
-			->with(Merchants::ME_PATH . "/integrations/configurations")
+			->with(Merchants::ME_PATH . "/configuration")
 			->once()
 			->andReturn($this->requestObject);
 		$this->requestObject->shouldReceive('post')->once()->andReturn($this->responseMock);

--- a/tests/Unit/Endpoints/MerchantsTest.php
+++ b/tests/Unit/Endpoints/MerchantsTest.php
@@ -11,6 +11,8 @@ use PHPUnit\Framework\TestCase;
 
 class MerchantsTest extends TestCase
 {
+	const URL = "https://www.example.com/integrations/configurations";
+
 	public function setUp(): void
 	{
 		$this->merchantEndpoint = Mockery::mock(Merchants::class)->makePartial();
@@ -29,7 +31,7 @@ class MerchantsTest extends TestCase
 	public function testSendIntegrationsConfigurationsUrlIsOk(){
 		$this->responseMock->shouldReceive('isError')->once()->andReturn(false);
 		$this->requestObject->shouldReceive('setRequestBody')
-			->with(['endpoint_url' => 'https://www.example.com/integrations/configurations'])
+			->with(['endpoint_url' => self::URL])
 			->andReturn($this->requestObject);
 
 		$this->merchantEndpoint->shouldReceive('request')
@@ -38,14 +40,14 @@ class MerchantsTest extends TestCase
 			->andReturn($this->requestObject);
 		$this->requestObject->shouldReceive('post')->once()->andReturn($this->responseMock);
 
-		$url = "https://www.example.com/integrations/configurations";
+		$url = self::URL;
 		$this->assertNull($this->merchantEndpoint->sendIntegrationsConfigurationsUrl($url));
 	}
 
 	public function testSendIntegrationsConfigurationsUrlThrowRequestException(){
 		$this->responseMock->shouldReceive('isError')->once()->andReturn(true);
 		$this->requestObject->shouldReceive('setRequestBody')
-			->with(['endpoint_url' => 'https://www.example.com/integrations/configurations'])
+			->with(['endpoint_url' => self::URL])
 			->andReturn($this->requestObject);
 
 		$this->merchantEndpoint->shouldReceive('request')
@@ -54,7 +56,7 @@ class MerchantsTest extends TestCase
 			->andReturn($this->requestObject);
 		$this->requestObject->shouldReceive('post')->once()->andReturn($this->responseMock);
 
-		$url = "https://www.example.com/integrations/configurations";
+		$url = self::URL;
 		$this->expectException(RequestException::class);
 		$this->merchantEndpoint->sendIntegrationsConfigurationsUrl($url);
 

--- a/tests/Unit/Entities/CmsFeaturesTest.php
+++ b/tests/Unit/Entities/CmsFeaturesTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Unit\Entities;
+
+use Alma\API\Entities\MerchantData\CmsFeatures;
+use PHPUnit\Framework\TestCase;
+
+class CmsFeaturesTest extends TestCase
+{
+	public function testConstructorSetsValuesCorrectly()
+	{
+		$data = [
+			'alma_enabled' => true,
+			'widget_cart_activated' => true,
+			'widget_product_activated' => false,
+			'used_fee_plans' => 'Plan A',
+			'payment_method_position' => 1,
+			'in_page_activated' => true,
+			'log_activated' => false,
+			'excluded_categories' => ['category1', 'category2'],
+			'excluded_categories_activated' => true,
+			'specific_features' => ['feature1', 'feature2'],
+			'country_restriction' => ['FR', 'US'],
+			'is_multisite' => false,
+			'custom_widget_css' => true,
+		];
+
+		$cmsFeatures = new CmsFeatures($data);
+
+		$this->assertEquals(true, $cmsFeatures->getProperties()['alma_enabled']);
+		$this->assertEquals(true, $cmsFeatures->getProperties()['widget_cart_activated']);
+		$this->assertEquals(false, $cmsFeatures->getProperties()['widget_product_activated']);
+		$this->assertEquals('Plan A', $cmsFeatures->getProperties()['used_fee_plans']);
+		$this->assertEquals(1, $cmsFeatures->getProperties()['payment_method_position']);
+		$this->assertEquals(true, $cmsFeatures->getProperties()['in_page_activated']);
+		$this->assertEquals(false, $cmsFeatures->getProperties()['log_activated']);
+		$this->assertEquals(['category1', 'category2'], $cmsFeatures->getProperties()['excluded_categories']);
+		$this->assertEquals(true, $cmsFeatures->getProperties()['excluded_categories_activated']);
+		$this->assertEquals(['feature1', 'feature2'], $cmsFeatures->getProperties()['specific_features']);
+		$this->assertEquals(['FR', 'US'], $cmsFeatures->getProperties()['country_restriction']);
+		$this->assertEquals(false, $cmsFeatures->getProperties()['is_multisite']);
+		$this->assertEquals(true, $cmsFeatures->getProperties()['custom_widget_css']);
+	}
+
+	public function testConstructorHandlesNullValuesCorrectly()
+	{
+		$data = [
+			'alma_enabled' => null,
+			'widget_cart_activated' => null,
+			'widget_product_activated' => null,
+			'used_fee_plans' => '',
+			'payment_method_position' => null,
+			'in_page_activated' => null,
+			'log_activated' => null,
+			'excluded_categories' => [],
+			'excluded_categories_activated' => null,
+			'specific_features' => [],
+			'country_restriction' => [],
+			'is_multisite' => null,
+			'custom_widget_css' => null,
+		];
+
+		$cmsFeatures = new CmsFeatures($data);
+		$properties = $cmsFeatures->getProperties();
+
+		$this->assertArrayNotHasKey('alma_enabled', $properties);
+		$this->assertArrayNotHasKey('widget_cart_activated', $properties);
+		$this->assertArrayNotHasKey('widget_product_activated', $properties);
+		$this->assertArrayNotHasKey('used_fee_plans', $properties);
+		$this->assertArrayNotHasKey('payment_method_position', $properties);
+		$this->assertArrayNotHasKey('in_page_activated', $properties);
+		$this->assertArrayNotHasKey('log_activated', $properties);
+		$this->assertEquals([], $properties['excluded_categories']); // Should be an empty array
+		$this->assertArrayNotHasKey('excluded_categories_activated', $properties);
+		$this->assertEquals([], $properties['specific_features']); // Should be an empty array
+		$this->assertEquals([], $properties['country_restriction']); // Should be an empty array
+		$this->assertArrayNotHasKey('is_multisite', $properties);
+		$this->assertArrayNotHasKey('custom_widget_css', $properties);
+	}
+
+	public function testGetPropertiesFiltersOutNullAndEmptyValues()
+	{
+		$data = [
+			'alma_enabled' => true,
+			'widget_cart_activated' => null,
+			'widget_product_activated' => null,
+			'used_fee_plans' => 'Plan B',
+			'payment_method_position' => null,
+			'in_page_activated' => false,
+			'log_activated' => null,
+			'excluded_categories' => ['category3'],
+			'excluded_categories_activated' => null,
+			'specific_features' => [],
+			'country_restriction' => [],
+			'is_multisite' => false,
+			'custom_widget_css' => null,
+		];
+
+		$cmsFeatures = new CmsFeatures($data);
+		$properties = $cmsFeatures->getProperties();
+
+		$this->assertArrayHasKey('alma_enabled', $properties);
+		$this->assertArrayNotHasKey('widget_cart_activated', $properties); // Should be filtered out (empty string)
+		$this->assertArrayNotHasKey('widget_product_activated', $properties); // Should be filtered out (null)
+		$this->assertArrayHasKey('used_fee_plans', $properties);
+		$this->assertArrayNotHasKey('payment_method_position', $properties); // Should be filtered out (null)
+		$this->assertArrayHasKey('in_page_activated', $properties);
+		$this->assertArrayHasKey('excluded_categories', $properties);
+		$this->assertArrayNotHasKey('excluded_categories_activated', $properties); // Should be filtered out (null)
+		$this->assertArrayHasKey('specific_features', $properties);
+		$this->assertArrayHasKey('country_restriction', $properties);
+		$this->assertArrayHasKey('is_multisite', $properties);
+		$this->assertArrayNotHasKey('custom_widget_css', $properties); // Should be filtered out (null)
+	}
+}

--- a/tests/Unit/Entities/CmsFeaturesTest.php
+++ b/tests/Unit/Entities/CmsFeaturesTest.php
@@ -13,7 +13,7 @@ class CmsFeaturesTest extends TestCase
 			'alma_enabled' => true,
 			'widget_cart_activated' => true,
 			'widget_product_activated' => false,
-			'used_fee_plans' => 'Plan A',
+			'used_fee_plans' => ['Plan A'],
 			'payment_method_position' => 1,
 			'in_page_activated' => true,
 			'log_activated' => false,
@@ -30,7 +30,7 @@ class CmsFeaturesTest extends TestCase
 		$this->assertTrue($cmsFeatures->getProperties()['alma_enabled']);
 		$this->assertTrue($cmsFeatures->getProperties()['widget_cart_activated']);
 		$this->assertFalse($cmsFeatures->getProperties()['widget_product_activated']);
-		$this->assertEquals('Plan A', $cmsFeatures->getProperties()['used_fee_plans']);
+		$this->assertEquals(['Plan A'], $cmsFeatures->getProperties()['used_fee_plans']);
 		$this->assertEquals(1, $cmsFeatures->getProperties()['payment_method_position']);
 		$this->assertTrue($cmsFeatures->getProperties()['in_page_activated']);
 		$this->assertFalse($cmsFeatures->getProperties()['log_activated']);
@@ -48,7 +48,7 @@ class CmsFeaturesTest extends TestCase
 			'alma_enabled' => null,
 			'widget_cart_activated' => null,
 			'widget_product_activated' => null,
-			'used_fee_plans' => '',
+			'used_fee_plans' => [],
 			'payment_method_position' => null,
 			'in_page_activated' => null,
 			'log_activated' => null,
@@ -66,7 +66,7 @@ class CmsFeaturesTest extends TestCase
 		$this->assertArrayNotHasKey('alma_enabled', $properties);
 		$this->assertArrayNotHasKey('widget_cart_activated', $properties);
 		$this->assertArrayNotHasKey('widget_product_activated', $properties);
-		$this->assertArrayNotHasKey('used_fee_plans', $properties);
+		$this->assertEquals([], $properties['used_fee_plans']);
 		$this->assertArrayNotHasKey('payment_method_position', $properties);
 		$this->assertArrayNotHasKey('in_page_activated', $properties);
 		$this->assertArrayNotHasKey('log_activated', $properties);
@@ -112,4 +112,25 @@ class CmsFeaturesTest extends TestCase
 		$this->assertArrayHasKey('is_multisite', $properties);
 		$this->assertArrayNotHasKey('custom_widget_css', $properties); // Should be filtered out (null)
 	}
+
+    public function testGetPropertiesFiltersOutWithEmptyData()
+    {
+        $data = [];
+
+        $cmsFeatures = new CmsFeatures($data);
+        $properties = $cmsFeatures->getProperties();
+
+        $this->assertArrayNotHasKey('alma_enabled', $properties);
+        $this->assertArrayNotHasKey('widget_cart_activated', $properties);
+        $this->assertArrayNotHasKey('widget_product_activated', $properties);
+        $this->assertEquals([], $properties['used_fee_plans']);
+        $this->assertArrayNotHasKey('payment_method_position', $properties);
+        $this->assertArrayNotHasKey('in_page_activated', $properties);
+        $this->assertEquals([], $properties['excluded_categories']);
+        $this->assertArrayNotHasKey('excluded_categories_activated', $properties);
+        $this->assertEquals([], $properties['specific_features']);
+        $this->assertEquals([], $properties['country_restriction']);
+        $this->assertArrayNotHasKey('is_multisite', $properties);
+        $this->assertArrayNotHasKey('custom_widget_css', $properties);
+    }
 }

--- a/tests/Unit/Entities/CmsFeaturesTest.php
+++ b/tests/Unit/Entities/CmsFeaturesTest.php
@@ -27,19 +27,19 @@ class CmsFeaturesTest extends TestCase
 
 		$cmsFeatures = new CmsFeatures($data);
 
-		$this->assertEquals(true, $cmsFeatures->getProperties()['alma_enabled']);
-		$this->assertEquals(true, $cmsFeatures->getProperties()['widget_cart_activated']);
-		$this->assertEquals(false, $cmsFeatures->getProperties()['widget_product_activated']);
+		$this->assertTrue($cmsFeatures->getProperties()['alma_enabled']);
+		$this->assertTrue($cmsFeatures->getProperties()['widget_cart_activated']);
+		$this->assertFalse($cmsFeatures->getProperties()['widget_product_activated']);
 		$this->assertEquals('Plan A', $cmsFeatures->getProperties()['used_fee_plans']);
 		$this->assertEquals(1, $cmsFeatures->getProperties()['payment_method_position']);
-		$this->assertEquals(true, $cmsFeatures->getProperties()['in_page_activated']);
-		$this->assertEquals(false, $cmsFeatures->getProperties()['log_activated']);
+		$this->assertTrue($cmsFeatures->getProperties()['in_page_activated']);
+		$this->assertFalse($cmsFeatures->getProperties()['log_activated']);
 		$this->assertEquals(['category1', 'category2'], $cmsFeatures->getProperties()['excluded_categories']);
-		$this->assertEquals(true, $cmsFeatures->getProperties()['excluded_categories_activated']);
+		$this->assertTrue($cmsFeatures->getProperties()['excluded_categories_activated']);
 		$this->assertEquals(['feature1', 'feature2'], $cmsFeatures->getProperties()['specific_features']);
 		$this->assertEquals(['FR', 'US'], $cmsFeatures->getProperties()['country_restriction']);
-		$this->assertEquals(false, $cmsFeatures->getProperties()['is_multisite']);
-		$this->assertEquals(true, $cmsFeatures->getProperties()['custom_widget_css']);
+		$this->assertFalse($cmsFeatures->getProperties()['is_multisite']);
+		$this->assertTrue($cmsFeatures->getProperties()['custom_widget_css']);
 	}
 
 	public function testConstructorHandlesNullValuesCorrectly()

--- a/tests/Unit/Entities/CmsInfoTest.php
+++ b/tests/Unit/Entities/CmsInfoTest.php
@@ -7,6 +7,9 @@ use PHPUnit\Framework\TestCase;
 
 class CmsInfoTest extends TestCase
 {
+	const SDK_VERSION = '2.0.0';
+	const SDK_NAME = 'Alma SDK';
+
 	public function testConstructorSetsValuesCorrectly()
 	{
 		$data = [
@@ -17,8 +20,8 @@ class CmsInfoTest extends TestCase
 			'language_name' => 'PHP',
 			'language_version' => '7.4',
 			'alma_plugin_version' => '1.0.0',
-			'alma_sdk_version' => '2.0.0',
-			'alma_sdk_name' => 'Alma SDK'
+			'alma_sdk_version' => self::SDK_VERSION,
+			'alma_sdk_name' => self::SDK_NAME
 		];
 
 		$cmsInfo = new CmsInfo($data);
@@ -30,8 +33,8 @@ class CmsInfoTest extends TestCase
 		$this->assertEquals('PHP', $cmsInfo->getProperties()['language_name']);
 		$this->assertEquals('7.4', $cmsInfo->getProperties()['language_version']);
 		$this->assertEquals('1.0.0', $cmsInfo->getProperties()['alma_plugin_version']);
-		$this->assertEquals('2.0.0', $cmsInfo->getProperties()['alma_sdk_version']);
-		$this->assertEquals('Alma SDK', $cmsInfo->getProperties()['alma_sdk_name']);
+		$this->assertEquals(self::SDK_VERSION, $cmsInfo->getProperties()['alma_sdk_version']);
+		$this->assertEquals(self::SDK_NAME, $cmsInfo->getProperties()['alma_sdk_name']);
 	}
 
 	public function testConstructorHandlesNullValuesCorrectly()
@@ -71,8 +74,8 @@ class CmsInfoTest extends TestCase
 			'language_name' => null,
 			'language_version' => '',
 			'alma_plugin_version' => null,
-			'alma_sdk_version' => '2.0.0',
-			'alma_sdk_name' => 'Alma SDK'
+			'alma_sdk_version' => self::SDK_VERSION,
+			'alma_sdk_name' => self::SDK_NAME
 		];
 
 		$cmsInfo = new CmsInfo($data);

--- a/tests/Unit/Entities/CmsInfoTest.php
+++ b/tests/Unit/Entities/CmsInfoTest.php
@@ -89,4 +89,21 @@ class CmsInfoTest extends TestCase
 		$this->assertArrayHasKey('alma_sdk_version', $properties);
 		$this->assertArrayHasKey('alma_sdk_name', $properties);
 	}
+
+    public function testGetPropertiesFiltersOutWithEmptyData()
+    {
+        $data = [];
+
+        $cmsInfo = new CmsInfo($data);
+        $properties = $cmsInfo->getProperties();
+
+        $this->assertArrayNotHasKey('cms_name', $properties);
+        $this->assertArrayNotHasKey('cms_version', $properties); // Should be filtered out (empty string)
+        $this->assertEquals([], $cmsInfo->getProperties()['third_parties_plugins']);
+        $this->assertEquals([], $cmsInfo->getProperties()['themes']);
+        $this->assertArrayNotHasKey('language_name', $properties); // Should be filtered out (null)
+        $this->assertArrayNotHasKey('language_version', $properties); // Should be filtered out (empty string)
+        $this->assertArrayNotHasKey('alma_sdk_version', $properties);
+        $this->assertArrayNotHasKey('alma_sdk_name', $properties);
+    }
 }

--- a/tests/Unit/Entities/CmsInfoTest.php
+++ b/tests/Unit/Entities/CmsInfoTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Unit\Entities;
+
+use Alma\API\Entities\MerchantData\CmsInfo;
+use PHPUnit\Framework\TestCase;
+
+class CmsInfoTest extends TestCase
+{
+	public function testConstructorSetsValuesCorrectly()
+	{
+		$data = [
+			'cms_name' => 'WordPress',
+			'cms_version' => '5.8',
+			'third_parties_plugins' => ['plugin1', 'plugin2'],
+			'themes' => ['theme1'],
+			'language_name' => 'PHP',
+			'language_version' => '7.4',
+			'alma_plugin_version' => '1.0.0',
+			'alma_sdk_version' => '2.0.0',
+			'alma_sdk_name' => 'Alma SDK'
+		];
+
+		$cmsInfo = new CmsInfo($data);
+
+		$this->assertEquals('WordPress', $cmsInfo->getProperties()['cms_name']);
+		$this->assertEquals('5.8', $cmsInfo->getProperties()['cms_version']);
+		$this->assertEquals(['plugin1', 'plugin2'], $cmsInfo->getProperties()['third_parties_plugins']);
+		$this->assertEquals(['theme1'], $cmsInfo->getProperties()['themes']);
+		$this->assertEquals('PHP', $cmsInfo->getProperties()['language_name']);
+		$this->assertEquals('7.4', $cmsInfo->getProperties()['language_version']);
+		$this->assertEquals('1.0.0', $cmsInfo->getProperties()['alma_plugin_version']);
+		$this->assertEquals('2.0.0', $cmsInfo->getProperties()['alma_sdk_version']);
+		$this->assertEquals('Alma SDK', $cmsInfo->getProperties()['alma_sdk_name']);
+	}
+
+	public function testConstructorHandlesNullValuesCorrectly()
+	{
+		$data = [
+			'cms_name' => null,
+			'cms_version' => null,
+			'third_parties_plugins' => [],
+			'themes' => [],
+			'language_name' => null,
+			'language_version' => null,
+			'alma_plugin_version' => null,
+			'alma_sdk_version' => null,
+			'alma_sdk_name' => null
+		];
+
+		$cmsInfo = new CmsInfo($data);
+
+		$this->assertArrayNotHasKey('cms_name', $cmsInfo->getProperties());
+		$this->assertArrayNotHasKey('cms_version', $cmsInfo->getProperties());
+		$this->assertArrayNotHasKey('language_name', $cmsInfo->getProperties());
+		$this->assertArrayNotHasKey('language_version', $cmsInfo->getProperties());
+		$this->assertArrayNotHasKey('alma_plugin_version', $cmsInfo->getProperties());
+		$this->assertArrayNotHasKey('alma_sdk_version', $cmsInfo->getProperties());
+		$this->assertArrayNotHasKey('alma_sdk_name', $cmsInfo->getProperties());
+		$this->assertEquals([], $cmsInfo->getProperties()['third_parties_plugins']);
+		$this->assertEquals([], $cmsInfo->getProperties()['themes']);
+	}
+
+	public function testGetPropertiesFiltersOutNullAndEmptyValues()
+	{
+		$data = [
+			'cms_name' => 'WordPress',
+			'cms_version' => '',
+			'third_parties_plugins' => ['plugin1'],
+			'themes' => [],
+			'language_name' => null,
+			'language_version' => '',
+			'alma_plugin_version' => null,
+			'alma_sdk_version' => '2.0.0',
+			'alma_sdk_name' => 'Alma SDK'
+		];
+
+		$cmsInfo = new CmsInfo($data);
+		$properties = $cmsInfo->getProperties();
+
+		$this->assertArrayHasKey('cms_name', $properties);
+		$this->assertArrayNotHasKey('cms_version', $properties); // Should be filtered out (empty string)
+		$this->assertArrayHasKey('third_parties_plugins', $properties);
+		$this->assertArrayNotHasKey('language_name', $properties); // Should be filtered out (null)
+		$this->assertArrayNotHasKey('language_version', $properties); // Should be filtered out (empty string)
+		$this->assertArrayHasKey('alma_sdk_version', $properties);
+		$this->assertArrayHasKey('alma_sdk_name', $properties);
+	}
+}

--- a/tests/Unit/Lib/PayloadFormatterTest.php
+++ b/tests/Unit/Lib/PayloadFormatterTest.php
@@ -9,6 +9,13 @@ use Alma\API\Entities\MerchantData\CmsFeatures;
 
 class PayloadFormatterTest extends TestCase
 {
+    var $payloadFormatter;
+
+    public function setUp(): void
+    {
+        $this->payloadFormatter = new PayloadFormatter();
+    }
+
 	public function testFormatIntegrationConfigurationPayload()
 	{
 		// Simulated input data for CmsInfo
@@ -44,7 +51,7 @@ class PayloadFormatterTest extends TestCase
 		$cmsFeatures = new CmsFeatures($cmsFeaturesData);
 
 		// Call the method to be tested
-		$result = PayloadFormatter::formatIntegrationConfigurationPayload($cmsInfo, $cmsFeatures);
+		$result = $this->payloadFormatter->formatConfigurationPayload($cmsInfo, $cmsFeatures);
 
 		// Expected result in JSON format
 		$expectedPayload = json_encode([
@@ -91,7 +98,7 @@ class PayloadFormatterTest extends TestCase
 		$cmsFeatures = new CmsFeatures($cmsFeaturesData);
 
 		// Call the method to be tested
-		$result = PayloadFormatter::formatIntegrationConfigurationPayload($cmsInfo, $cmsFeatures);
+		$result = $this->payloadFormatter->formatConfigurationPayload($cmsInfo, $cmsFeatures);
 
 		// Expected result in JSON format (should not include keys with null or empty values)
 		$expectedPayload = json_encode([

--- a/tests/Unit/Lib/PayloadFormatterTest.php
+++ b/tests/Unit/Lib/PayloadFormatterTest.php
@@ -54,13 +54,13 @@ class PayloadFormatterTest extends TestCase
 		$result = $this->payloadFormatter->formatConfigurationPayload($cmsInfo, $cmsFeatures);
 
 		// Expected result in JSON format
-		$expectedPayload = json_encode([
+		$expectedPayload = [
 			'cms_info' => $cmsInfo->getProperties(),
 			'cms_features' => $cmsFeatures->getProperties(),
-		]);
+		];
 
 		// Assertion: Check if the output matches the expected JSON payload
-		$this->assertJsonStringEqualsJsonString($expectedPayload, $result);
+		$this->assertEquals($expectedPayload, $result);
 	}
 
 	public function testFormatIntegrationConfigurationPayloadWithEmptyValues()
@@ -101,12 +101,12 @@ class PayloadFormatterTest extends TestCase
 		$result = $this->payloadFormatter->formatConfigurationPayload($cmsInfo, $cmsFeatures);
 
 		// Expected result in JSON format (should not include keys with null or empty values)
-		$expectedPayload = json_encode([
+		$expectedPayload = [
 			'cms_info' => $cmsInfo->getProperties(),
 			'cms_features' => $cmsFeatures->getProperties(),
-		]);
+		];
 
 		// Assertion: Check if the output matches the expected JSON payload
-		$this->assertJsonStringEqualsJsonString($expectedPayload, $result);
+		$this->assertEquals($expectedPayload, $result);
 	}
 }

--- a/tests/Unit/Lib/PayloadFormatterTest.php
+++ b/tests/Unit/Lib/PayloadFormatterTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Unit\Lib;
+
+use Alma\API\Lib\PayloadFormatter;
+use PHPUnit\Framework\TestCase;
+use Alma\API\Entities\MerchantData\CmsInfo;
+use Alma\API\Entities\MerchantData\CmsFeatures;
+
+class PayloadFormatterTest extends TestCase
+{
+	public function testFormatIntegrationConfigurationPayload()
+	{
+		// Simulated input data for CmsInfo
+		$cmsInfoData = [
+			'cms_name' => 'WordPress',
+			'cms_version' => '5.8',
+			'third_parties_plugins' => [['name' => 'plugin1', 'version' => '1.0']],
+			'themes' => [['name' => 'theme1', 'version' => '2.0']],
+			'language_name' => 'PHP',
+			'language_version' => '7.4',
+			'alma_plugin_version' => '1.0.0',
+			'alma_sdk_version' => '2.0.0',
+			'alma_sdk_name' => 'Alma SDK'
+		];
+		$cmsInfo = new CmsInfo($cmsInfoData);
+
+		// Simulated input data for CmsFeatures
+		$cmsFeaturesData = [
+			'alma_enabled' => true,
+			'widget_cart_activated' => true,
+			'widget_product_activated' => false,
+			'used_fee_plans' => '{"plan":"A"}',
+			'payment_method_position' => 1,
+			'in_page_activated' => true,
+			'log_activated' => false,
+			'excluded_categories' => ['category1'],
+			'excluded_categories_activated' => true,
+			'specific_features' => [['name' => 'feature1']],
+			'country_restriction' => ['FR', 'US'],
+			'is_multisite' => false,
+			'custom_widget_css' => true,
+		];
+		$cmsFeatures = new CmsFeatures($cmsFeaturesData);
+
+		// Call the method to be tested
+		$result = PayloadFormatter::formatIntegrationConfigurationPayload($cmsInfo, $cmsFeatures);
+
+		// Expected result in JSON format
+		$expectedPayload = json_encode([
+			'cms_info' => $cmsInfo->getProperties(),
+			'cms_features' => $cmsFeatures->getProperties(),
+		]);
+
+		// Assertion: Check if the output matches the expected JSON payload
+		$this->assertJsonStringEqualsJsonString($expectedPayload, $result);
+	}
+
+	public function testFormatIntegrationConfigurationPayloadWithEmptyValues()
+	{
+		// CmsInfo with null or empty values
+		$cmsInfoData = [
+			'cms_name' => null,
+			'cms_version' => '',
+			'third_parties_plugins' => [],
+			'themes' => [],
+			'language_name' => null,
+			'language_version' => '',
+			'alma_plugin_version' => null,
+			'alma_sdk_version' => null,
+			'alma_sdk_name' => null
+		];
+		$cmsInfo = new CmsInfo($cmsInfoData);
+
+		// CmsFeatures with null or empty values
+		$cmsFeaturesData = [
+			'alma_enabled' => null,
+			'widget_cart_activated' => null,
+			'widget_product_activated' => null,
+			'used_fee_plans' => '',
+			'payment_method_position' => null,
+			'in_page_activated' => null,
+			'log_activated' => null,
+			'excluded_categories' => [],
+			'excluded_categories_activated' => null,
+			'specific_features' => [],
+			'country_restriction' => [],
+			'is_multisite' => null,
+			'custom_widget_css' => null,
+		];
+		$cmsFeatures = new CmsFeatures($cmsFeaturesData);
+
+		// Call the method to be tested
+		$result = PayloadFormatter::formatIntegrationConfigurationPayload($cmsInfo, $cmsFeatures);
+
+		// Expected result in JSON format (should not include keys with null or empty values)
+		$expectedPayload = json_encode([
+			'cms_info' => $cmsInfo->getProperties(),
+			'cms_features' => $cmsFeatures->getProperties(),
+		]);
+
+		// Assertion: Check if the output matches the expected JSON payload
+		$this->assertJsonStringEqualsJsonString($expectedPayload, $result);
+	}
+}


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding Linear task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2116/[-php-client]-create-endpoint-that-returns-data)
We need to implement new endpoint to save an url for gathering CMS data. 

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

- Add new endpoint in Merchants.php file
- Add a formatter for gathering CMS data payload
- Add CmsInfos and CmsFeatures Entity
- Add some unit tests

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
You can run unit tests

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->