### PR TITLE
feat: replace payment validator hmac verification by request hmac val…

### DIFF
--- a/src/Lib/PaymentValidator.php
+++ b/src/Lib/PaymentValidator.php
@@ -58,15 +58,16 @@ class PaymentValidator
     }
 
     /**
+     * Validate the HMAC signature of the request
+     *
      * @param string $data
      * @param string $apiKey
      * @param string $signature
+     * @deprecated Use RequestUtils::isHmacValidated instead
      * @return bool
      */
     public function isHmacValidated($data, $apiKey,  $signature)
     {
-        return is_string($data) &&
-            is_string($apiKey) &&
-            hash_hmac('sha256', $data, $apiKey) === $signature;
+        return RequestUtils::isHmacValidated($data, $apiKey, $signature);
     }
 }

--- a/src/Lib/RequestUtils.php
+++ b/src/Lib/RequestUtils.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Alma\API\Lib;
+
+class RequestUtils
+{
+    /**
+     * Validate the HMAC signature of the request
+     *
+     * @param string $data
+     * @param string $apiKey
+     * @param string $signature
+     * @return bool
+     */
+    public static function isHmacValidated($data, $apiKey,  $signature)
+    {
+        return is_string($data) &&
+            is_string($apiKey) &&
+            hash_hmac('sha256', $data, $apiKey) === $signature;
+    }
+
+}

--- a/tests/Unit/Lib/RequestUtilsTest.php
+++ b/tests/Unit/Lib/RequestUtilsTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Alma\API\Tests\Unit\Lib;
+
+use Alma\API\Lib\RequestUtils;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+class RequestUtilsTest extends TestCase
+{
+    public function testValidateRequestSignature()
+    {
+        $data = 'merchant_id_test';
+        $apiKey = 'api_key_test';
+        $signature = '0dd3cb4632c074ead0d0f346c75015c76ad4e1e115f01c7e0850dd5accb7b4b0';
+
+        $this->assertTrue(RequestUtils::isHmacValidated($data, $apiKey,  $signature));
+    }
+    /**
+     * @dataProvider checkHmacInvalidDataProvider
+     * @param $data
+     * @param $apiKey
+     * @param $signature
+     * @return void
+     */
+    public function testHmacDataDifferentFromSignature($data, $apiKey,  $signature)
+    {
+        $this->assertFalse(RequestUtils::isHmacValidated($data, $apiKey,  $signature));
+    }
+
+    public static function checkHmacInvalidDataProvider()
+    {
+        return [
+            'String data' => [
+                'data' => 'payment_id_test',
+                'apiKey' => 'api_key_test',
+                'signature' => 'wrong_signature'
+            ],
+            'Empty array data' => [
+                'data' => [],
+                'apiKey' => 'api_key_test',
+                'signature' => 'wrong_signature'
+            ],
+            'Empty array apiKey' => [
+                'data' => 'payment_id_test',
+                'apiKey' => [],
+                'signature' => 'wrong_signature'
+            ],
+            'Empty array signature' => [
+                'data' => 'payment_id_test',
+                'apiKey' => 'api_key_test',
+                'signature' => []
+            ],
+            'Empty string data' => [
+                'data' => '',
+                'apiKey' => 'api_key_test',
+                'signature' => 'wrong_signature'
+            ],
+            'Empty string apiKey' => [
+                'data' => 'payment_id_test',
+                'apiKey' => '',
+                'signature' => 'wrong_signature'
+            ],
+            'Empty string signature' => [
+                'data' => 'payment_id_test',
+                'apiKey' => 'api_key_test',
+                'signature' => ''
+            ],
+            'Object data' => [
+                'data' => new stdClass(),
+                'apiKey' => 'api_key_test',
+                'signature' => 'wrong_signature'
+            ],
+            'Object apiKey' => [
+                'data' => 'payment_id_test',
+                'apiKey' => new stdClass(),
+                'signature' => 'wrong_signature'
+            ],
+            'Object signature' => [
+                'data' => 'payment_id_test',
+                'apiKey' => 'api_key_test',
+                'signature' => new stdClass()
+            ],
+            'Boolean data' => [
+                'data' => false,
+                'apiKey' => 'api_key_test',
+                'signature' => 'wrong_signature'
+            ],
+            'Boolean apiKey' => [
+                'data' => 'payment_id_test',
+                'apiKey' => true,
+                'signature' => 'wrong_signature'
+            ],
+            'Boolean signature' => [
+                'data' => 'payment_id_test',
+                'apiKey' => 'api_key_test',
+                'signature' => true
+            ],
+            'Int data' => [
+                'data' => 1,
+                'apiKey' => 'api_key_test',
+                'signature' => 'wrong_signature'
+            ],
+            'Int apiKey' => [
+                'data' => 'payment_id_test',
+                'apiKey' => 2,
+                'signature' => 'wrong_signature'
+            ],
+            'Int signature' => [
+                'data' => 'payment_id_test',
+                'apiKey' => 'api_key_test',
+                'signature' => 3
+            ]
+
+        ];
+    }
+
+}


### PR DESCRIPTION
### Reason for change

Deprecate payment validator hmac validation and create requestUtils with hmac validation

[Linear task](https://linear.app/almapay/issue/ECOM-XXX)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->