### PR TITLE
fix: Not allow empty string for order confirmed business event construct

### DIFF
--- a/src/Entities/DTO/MerchantBusinessEvent/OrderConfirmedBusinessEvent.php
+++ b/src/Entities/DTO/MerchantBusinessEvent/OrderConfirmedBusinessEvent.php
@@ -128,8 +128,8 @@ class OrderConfirmedBusinessEvent extends AbstractBusinessEvent
             !is_bool($this->almaP1XStatus) ||
             !is_bool($this->almaBNPLStatus) ||
             !is_bool($this->wasBNPLEligible) ||
-            !is_string($this->orderId) ||
-            !is_string($this->cartId) ||
+            (!is_string($this->orderId) || empty($this->orderId)) ||
+            (!is_string($this->cartId) || empty($this->cartId)) ||
             // Alma payment id should be absent for non Alma payments
             (!$this->isAlmaPayment() && !is_null($this->almaPaymentId))
         )
@@ -140,7 +140,7 @@ class OrderConfirmedBusinessEvent extends AbstractBusinessEvent
         //Alma payment id for Alma payment, Must be a string
         if(
             $this->isAlmaPayment() &&
-            !is_string($this->almaPaymentId)
+            (!is_string($this->almaPaymentId) || empty($this->almaPaymentId))
         )
         {
             throw new ParametersException('Alma payment id is mandatory for Alma payment');

--- a/tests/Unit/Entities/DTO/MerchantBusinessEvent/OrderConfirmedBusinessEventTest.php
+++ b/tests/Unit/Entities/DTO/MerchantBusinessEvent/OrderConfirmedBusinessEventTest.php
@@ -52,6 +52,11 @@ class OrderConfirmedBusinessEventTest extends TestCase
         $this->expectException(ParametersException::class);
         new OrderConfirmedBusinessEvent(false, true, true, "42", "54");
     }
+    public function testAlmaPaymentIdCanNotBeAnEmptyStringForAnAlmaPayment()
+    {
+        $this->expectException(ParametersException::class);
+        new OrderConfirmedBusinessEvent(false, true, true, "42", "54", "");
+    }
 
     public function testAlmaPaymentIdShouldBeAbsentForNonAlmaPayments()
     {
@@ -201,6 +206,13 @@ class OrderConfirmedBusinessEventTest extends TestCase
                 'orderId' => "1",
                 'cartId' => "1"
             ],
+            "Order id is empty string" => [
+                'isP1X' => false,
+                'isBNPL' => false,
+                'wasEligible' => true,
+                'orderId' => "",
+                'cartId' => "14"
+            ],
             "Order id is an int" => [
                 'isP1X' => false,
                 'isBNPL' => false,
@@ -270,6 +282,13 @@ class OrderConfirmedBusinessEventTest extends TestCase
                 'wasEligible' => true,
                 'orderId' => '1',
                 'cartId' => new \stdClass()
+            ],
+            "Cart id is empty string" => [
+                'isP1X' => false,
+                'isBNPL' => false,
+                'wasEligible' => true,
+                'orderId' => "1",
+                'cartId' => ""
             ],
         ];
     }


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding Linear task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2391/[php-client]-not-allow-empty-string-for-payment-id-order-id-and-cart)

### Code changes

Throw exception for empty string in OrderConfirmedEvent DTO

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->