### PR TITLE
Refactor: deprecated customer_fee_fixed

### DIFF
--- a/src/Entities/FeePlan.php
+++ b/src/Entities/FeePlan.php
@@ -68,8 +68,8 @@ class FeePlan extends Base implements PaymentPlanInterface
 	/** @var int Percentage of lending rate in bps used to calculate the fee plan interest paid by the customer (100bps = 1%) */
     public $customer_lending_rate;
 
-    /** @var int Fixed fees in cents paid for by the customer */
-    public $customer_fee_fixed;
+    /** @var int Fixed fees in cents paid for by the customer: Deprecated in the FeePlan*/
+    public $customer_fee_fixed = 0;
 
     public function getDeferredDays()
     {


### PR DESCRIPTION
### Reason for change

The attribute `customer_fee_fixed` is not used anymore. The last use case was a workaround to meet the belgium regulation. Since we released the belgium capping, there is no use case anymore. 

<img width="1118" height="675" alt="image" src="https://github.com/user-attachments/assets/bc814aad-50b6-4bbc-bb40-95937a3b48f3" />

The 2 first step of the column removal described [here](https://main-doc.alma.tech/developing/api/tutorials/databases/#dropping-a-column-from-a-table) has be done in: 
- https://github.com/alma/main/pull/25896
- https://github.com/alma/main/pull/25909

This PR https://github.com/alma/main/pull/25911 won't be merged before this one is. 