### PR TITLE
Feature/ecom 3597 add php8 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,18 @@ RUN apt update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 
-RUN case ${PHP_VERSION} in \
-        8.0|8.1|8.2|8.3 ) pecl install xdebug-3.3.2 && docker-php-ext-enable xdebug;; \
-        *) pecl install xdebug-2.9.8 && docker-php-ext-enable xdebug;; \
+RUN case "${PHP_VERSION}" in \
+        7.* ) \
+            echo "Installing Xdebug 2.9.8 for PHP ${PHP_VERSION}"; \
+            pecl install xdebug-2.9.8 && docker-php-ext-enable xdebug \
+        ;; \
+        8.0|8.1|8.2|8.3 ) \
+            echo "Installing Xdebug 3.3.2 for PHP ${PHP_VERSION}"; \
+            pecl install xdebug-3.3.2 && docker-php-ext-enable xdebug \
+        ;; \
+        * ) \
+            echo "PHP ${PHP_VERSION} >= 8.4 — skipping Xdebug installation"; \
+        ;; \
     esac
 
 RUN usermod -u 1000 www-data

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -33,6 +33,16 @@ includes:
     vars:
       PHP_VERSION: "8.3"
       PHPUNIT_FILE: phpunit.dist.8.xml
+  "8.4":
+    taskfile: Taskfile.php.yml
+    vars:
+      PHP_VERSION: "8.4"
+      PHPUNIT_FILE: phpunit.dist.8.xml
+  "8.5":
+    taskfile: Taskfile.php.yml
+    vars:
+      PHP_VERSION: "8.5"
+      PHPUNIT_FILE: phpunit.dist.8.xml
 
 tasks:
   default:

--- a/src/Application/DTO/MerchantBusinessEvent/OrderConfirmedBusinessEventDto.php
+++ b/src/Application/DTO/MerchantBusinessEvent/OrderConfirmedBusinessEventDto.php
@@ -44,17 +44,15 @@ class OrderConfirmedBusinessEventDto
      * @param bool $wasBNPLEligible
      * @param string $orderId
      * @param string $cartId
-     * @param string | null $almaPaymentId
      * @throws ParametersException
      */
-    public function __construct(bool $isAlmaP1X, bool $isAlmaBNPL, bool $wasBNPLEligible, string $orderId, string $cartId, string $almaPaymentId = null)
+    public function __construct(bool $isAlmaP1X, bool $isAlmaBNPL, bool $wasBNPLEligible, string $orderId, string $cartId)
     {
         $this->setIsAlmaP1X($isAlmaP1X);
         $this->setIsAlmaBNPL($isAlmaBNPL);
         $this->setWasBNPLEligible($wasBNPLEligible);
         $this->setOrderId($orderId);
         $this->setCartId($cartId);
-        $this->setAlmaPaymentId($almaPaymentId);
         $this->validateData();
     }
 
@@ -118,7 +116,7 @@ class OrderConfirmedBusinessEventDto
         $this->cartId = $cartId;
     }
 
-    private function setAlmaPaymentId(?string $almaPaymentId): void
+    private function setAlmaPaymentId(string $almaPaymentId): void
     {
         $this->almaPaymentId = $almaPaymentId;
     }

--- a/src/Application/DTO/MerchantBusinessEvent/OrderConfirmedBusinessEventDto.php
+++ b/src/Application/DTO/MerchantBusinessEvent/OrderConfirmedBusinessEventDto.php
@@ -39,20 +39,22 @@ class OrderConfirmedBusinessEventDto
      * For non alma payment, almaPaymentId should be null
      * For Alma payment, almaPaymentId should be a string
      *
-     * @param bool $isAlmaP1X
-     * @param bool $isAlmaBNPL
-     * @param bool $wasBNPLEligible
-     * @param string $orderId
-     * @param string $cartId
+     * @param bool $isAlmaP1X Whether the order was paid with Alma P1X
+     * @param bool $isAlmaBNPL Whether the order was paid with Alma BNPL
+     * @param bool $wasBNPLEligible Whether the order was eligible for BNPL
+     * @param string $orderId The order identifier
+     * @param string $cartId The cart identifier
+     * @param string|null $almaPaymentId Mandatory for Alma payments, should be null for non Alma payments
      * @throws ParametersException
      */
-    public function __construct(bool $isAlmaP1X, bool $isAlmaBNPL, bool $wasBNPLEligible, string $orderId, string $cartId)
+    public function __construct(bool $isAlmaP1X, bool $isAlmaBNPL, bool $wasBNPLEligible, string $orderId, string $cartId, string $almaPaymentId = '')
     {
         $this->setIsAlmaP1X($isAlmaP1X);
         $this->setIsAlmaBNPL($isAlmaBNPL);
         $this->setWasBNPLEligible($wasBNPLEligible);
         $this->setOrderId($orderId);
         $this->setCartId($cartId);
+        $this->setAlmaPaymentId($almaPaymentId);
         $this->validateData();
     }
 
@@ -76,7 +78,7 @@ class OrderConfirmedBusinessEventDto
             (empty($this->orderId)) ||
             (empty($this->cartId)) ||
             // Alma payment id should be absent for non Alma payments
-            (!$this->isAlmaPayment() && !is_null($this->almaPaymentId))
+            (!$this->isAlmaPayment() && !empty($this->almaPaymentId))
         )
         {
             throw new ParametersException('Invalid data type in OrderConfirmedBusinessEvent constructor');

--- a/src/Infrastructure/CurlClient.php
+++ b/src/Infrastructure/CurlClient.php
@@ -91,7 +91,7 @@ class CurlClient implements ClientInterface
         }
 
         $url = $this->config->getEnvironment()->getBaseUri() . $request->getUri()->getPath();
-        $this->logger->debug('Sending request to: ' . $request->getUri()->getPath());
+        $this->logger->debug('Sending request to: ' . $request->getUri()->getPath() . '<br />' . json_encode(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS)));
         $query = $request->getUri()->getQuery();
         if (!empty($query)) {
             $url .= '?' . $query;
@@ -123,7 +123,7 @@ class CurlClient implements ClientInterface
         // Getting the HTTP status code and headers
         $statusCode = $this->getInfo( CURLINFO_HTTP_CODE);
         $responseHeaders = $this->getInfo( CURLINFO_HEADER_SIZE);
-        $httpVersion = $this->getInfo(CURLINFO_HTTP_VERSION);
+        $httpVersion = $this->getHttpVersion($this->getInfo(CURLINFO_HTTP_VERSION));
         $headerString = substr($response, 0, $responseHeaders);
         $bodyContent = substr($response, $responseHeaders);
         $this->close();
@@ -181,6 +181,26 @@ class CurlClient implements ClientInterface
     public function getInfo(int $option = 0)
     {
         return curl_getinfo($this->curlClient, $option);
+    }
+
+    public function getHttpVersion(string $curlHttpVersion)
+    {
+        switch ($curlHttpVersion) {
+            case CURL_HTTP_VERSION_1_0:
+                $httpVersion = '1.0';
+                break;
+            case CURL_HTTP_VERSION_2_0:
+            case CURL_HTTP_VERSION_2TLS:
+            case CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE:
+                $httpVersion = '2.0';
+                break;
+            case CURL_HTTP_VERSION_1_1:
+            default:
+                $httpVersion = '1.1';
+                break;
+        }
+
+        return $httpVersion;
     }
 
     /** @codeCoverageIgnore Curl Wrapper used to test sendRequest function */

--- a/src/Infrastructure/CurlClient.php
+++ b/src/Infrastructure/CurlClient.php
@@ -47,7 +47,7 @@ class CurlClient implements ClientInterface
 
     use LoggerAwareTrait;
 
-    public function __construct(ClientConfiguration $config, LoggerInterface $logger = null)
+    public function __construct(ClientConfiguration $config, ?LoggerInterface $logger = null)
     {
         $this->config = $config;
         $this->logger = $logger ?? new NullLogger();
@@ -159,7 +159,7 @@ class CurlClient implements ClientInterface
     }
 
     /** @codeCoverageIgnore Curl Wrapper used to test sendRequest function */
-    public function init(string $url = null): bool
+    public function init(?string $url = null): bool
     {
         $this->curlClient = curl_init($url);
         return $this->curlClient !== false;

--- a/src/Infrastructure/Endpoint/AbstractEndpoint.php
+++ b/src/Infrastructure/Endpoint/AbstractEndpoint.php
@@ -4,6 +4,7 @@ namespace Alma\API\Infrastructure\Endpoint;
 
 use Alma\API\Infrastructure\CurlClient;
 use Alma\API\Infrastructure\Request;
+use Psr\Http\Client\ClientInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
@@ -12,14 +13,14 @@ abstract class AbstractEndpoint implements LoggerAwareInterface
 {
     use loggerAwareTrait;
 
-    /** @var CurlClient */
-    protected CurlClient $client;
+    /** @var ClientInterface */
+    protected ClientInterface $client;
 
     /**
      * Init the Endpoint
-     * @param CurlClient $client The Client to use with the Endpoint
+     * @param ClientInterface $client The Client to use with the Endpoint
      */
-    public function __construct(CurlClient $client)
+    public function __construct(ClientInterface $client)
     {
         $this->client = $client;
         $this->logger = new NullLogger();

--- a/src/Infrastructure/Endpoint/OrderEndpoint.php
+++ b/src/Infrastructure/Endpoint/OrderEndpoint.php
@@ -38,13 +38,6 @@ class OrderEndpoint extends AbstractEndpoint
     use PaginatedResultCompatibilityTrait;
     const ORDERS_ENDPOINT_V1 = '/v1/orders';
     const ORDERS_ENDPOINT = '/v2/orders';
-    private ArrayHelper $arrayUtils;
-
-    public function __construct(ClientInterface $client)
-    {
-        parent::__construct($client);
-        $this->arrayUtils = new ArrayHelper();
-    }
 
     /**
      * @param string $orderId

--- a/src/Infrastructure/Endpoint/OrderEndpoint.php
+++ b/src/Infrastructure/Endpoint/OrderEndpoint.php
@@ -29,12 +29,13 @@ use Alma\API\Domain\Entity\Order;
 use Alma\API\Infrastructure\Exception\Endpoint\OrderEndpointException;
 use Alma\API\Infrastructure\Exception\ParametersException;
 use Alma\API\Infrastructure\Helper\ArrayHelper;
-use Alma\API\Infrastructure\PaginatedResult;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
+use Alma\API\Infrastructure\PaginatedResultCompatibilityTrait;
 
 class OrderEndpoint extends AbstractEndpoint
 {
+    use PaginatedResultCompatibilityTrait;
     const ORDERS_ENDPOINT_V1 = '/v1/orders';
     const ORDERS_ENDPOINT = '/v2/orders';
     private ArrayHelper $arrayUtils;
@@ -113,7 +114,7 @@ class OrderEndpoint extends AbstractEndpoint
      * @return PaginatedResult
      * @throws OrderEndpointException
      */
-    public function fetchAll(int $limit = 20, string $startingAfter = null, array $filters = array()): PaginatedResult
+    public function fetchAll(int $limit = 20, ?string $startingAfter = null, array $filters = array()): PaginatedResult
     {
         $args = array(
             'limit' => $limit,

--- a/src/Infrastructure/Endpoint/PaymentEndpoint.php
+++ b/src/Infrastructure/Endpoint/PaymentEndpoint.php
@@ -167,7 +167,7 @@ class PaymentEndpoint extends AbstractEndpoint
      * @return void
      * @throws PaymentEndpointException
      */
-    public function flagAsPotentialFraud(string $id, string $reason = null): void
+    public function flagAsPotentialFraud(string $id, ?string $reason = null): void
     {
         $request = null;
         $data = [];

--- a/src/Infrastructure/PaginatedResult7.php
+++ b/src/Infrastructure/PaginatedResult7.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Copyright (c) 2018 Alma / Nabla SAS
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma / Nabla SAS <contact@getalma.eu>
+ * @copyright Copyright (c) 2018 Alma / Nabla SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace Alma\API\Infrastructure;
+
+use Iterator;
+
+class PaginatedResult7 implements Iterator
+{
+    /** @var int */
+    protected int $position = 0;
+
+    /** @var ResponseInterface */
+    protected ResponseInterface $response;
+
+    /**
+     * @var callable
+     */
+    protected $nextPageCallback;
+    private $entities;
+
+    /**
+     * PaginatedResults constructor.
+     *
+     * @param Response $response
+     * @param callable|null $nextPageCallback
+     */
+    public function __construct(ResponseInterface $response, ?callable $nextPageCallback)
+    {
+        $this->response         = $response;
+        $this->entities         = $response->getJson()['data'] ?? [];
+        $this->nextPageCallback = $nextPageCallback;
+    }
+
+    /**
+     * Rewind the iterator.
+     * @return void
+     */
+    public function rewind(): void
+    {
+        $this->position = 0;
+    }
+
+    /**
+     * Return the current entity.
+     * @return mixed
+     */
+    public function current()
+    {
+        return $this->entities[$this->position];
+    }
+
+    /**
+     * Return the current entity key.
+     * @return int The current entity key.
+     */
+    public function key(): int
+    {
+        return $this->position;
+    }
+
+    /**
+     * Move to the next entity.
+     * @return void
+     */
+    public function next(): void
+    {
+        ++$this->position;
+    }
+
+    /**
+     * Check if there is a next entity.
+     * @return bool
+     */
+    public function valid(): bool
+    {
+        return isset($this->entities[$this->position]);
+    }
+
+    /**
+     * Move to the next page.
+     * @return PaginatedResult
+     */
+    public function nextPage(): PaginatedResult
+    {
+        $callback = $this->nextPageCallback;
+        if (!$callback || !array_key_exists('has_more', $this->response->getJson())) {
+            return new self(new Response(204), null);
+        }
+
+        return $callback(array_slice($this->entities, -1, 1)[0]['id']);
+    }
+}

--- a/src/Infrastructure/PaginatedResult7.php
+++ b/src/Infrastructure/PaginatedResult7.php
@@ -26,42 +26,8 @@ namespace Alma\API\Infrastructure;
 
 use Iterator;
 
-class PaginatedResult7 implements Iterator
+class PaginatedResult7 extends abstractPaginatedResult implements Iterator
 {
-    /** @var int */
-    protected int $position = 0;
-
-    /** @var ResponseInterface */
-    protected ResponseInterface $response;
-
-    /**
-     * @var callable
-     */
-    protected $nextPageCallback;
-    private $entities;
-
-    /**
-     * PaginatedResults constructor.
-     *
-     * @param Response $response
-     * @param callable|null $nextPageCallback
-     */
-    public function __construct(ResponseInterface $response, ?callable $nextPageCallback)
-    {
-        $this->response         = $response;
-        $this->entities         = $response->getJson()['data'] ?? [];
-        $this->nextPageCallback = $nextPageCallback;
-    }
-
-    /**
-     * Rewind the iterator.
-     * @return void
-     */
-    public function rewind(): void
-    {
-        $this->position = 0;
-    }
-
     /**
      * Return the current entity.
      * @return mixed
@@ -72,37 +38,10 @@ class PaginatedResult7 implements Iterator
     }
 
     /**
-     * Return the current entity key.
-     * @return int The current entity key.
-     */
-    public function key(): int
-    {
-        return $this->position;
-    }
-
-    /**
-     * Move to the next entity.
-     * @return void
-     */
-    public function next(): void
-    {
-        ++$this->position;
-    }
-
-    /**
-     * Check if there is a next entity.
-     * @return bool
-     */
-    public function valid(): bool
-    {
-        return isset($this->entities[$this->position]);
-    }
-
-    /**
      * Move to the next page.
-     * @return PaginatedResult
+     * @return PaginatedResult7
      */
-    public function nextPage(): PaginatedResult
+    public function nextPage(): PaginatedResult7
     {
         $callback = $this->nextPageCallback;
         if (!$callback || !array_key_exists('has_more', $this->response->getJson())) {

--- a/src/Infrastructure/PaginatedResult8.php
+++ b/src/Infrastructure/PaginatedResult8.php
@@ -26,7 +26,7 @@ namespace Alma\API\Infrastructure;
 
 use Iterator;
 
-class PaginatedResult implements Iterator
+class PaginatedResult8 implements Iterator
 {
     /** @var int */
     protected int $position = 0;
@@ -66,7 +66,7 @@ class PaginatedResult implements Iterator
      * Return the current entity.
      * @return mixed
      */
-    public function current()
+    public function current(): mixed
     {
         return $this->entities[$this->position];
     }
@@ -100,7 +100,7 @@ class PaginatedResult implements Iterator
 
     /**
      * Move to the next page.
-     * @return self
+     * @return PaginatedResult
      */
     public function nextPage(): PaginatedResult
     {

--- a/src/Infrastructure/PaginatedResultCompatibilityTrait.php
+++ b/src/Infrastructure/PaginatedResultCompatibilityTrait.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Alma\API\Infrastructure;
+
+// Patch to be compatible with PHP7 and PHP8
+use Alma\API\Infrastructure\Endpoint\PaginatedResult;
+
+if (PHP_VERSION_ID < 80000) {
+    class_alias(
+        PaginatedResult7::class,
+        PaginatedResult::class
+    );
+} else {
+    class_alias(
+        PaginatedResult8::class,
+        PaginatedResult::class
+    );
+}
+
+/**
+ * The ony interrest of this trait is to add aliases to PaginatedResult for compatibility reasons.
+ */
+trait PaginatedResultCompatibilityTrait
+{
+
+}

--- a/src/Infrastructure/Response.php
+++ b/src/Infrastructure/Response.php
@@ -156,7 +156,6 @@ class Response implements ResponseInterface
     {
         $data = json_decode($this->body, true);
         if (json_last_error() !== JSON_ERROR_NONE) {
-            // Gérer l'erreur de décodage JSON (throw new \Exception, par exemple)
             return null;
         }
         return $data;

--- a/tests/Integration/Infrastructure/Endpoint/OrderEndpointTest.php
+++ b/tests/Integration/Infrastructure/Endpoint/OrderEndpointTest.php
@@ -4,7 +4,8 @@ namespace Alma\API\Tests\Integration\Infrastructure\Endpoint;
 
 use Alma\API\Domain\Entity\Order;
 use Alma\API\Infrastructure\Endpoint\OrderEndpoint;
-use Alma\API\Infrastructure\PaginatedResult;
+use Alma\API\Infrastructure\PaginatedResult7;
+use Alma\API\Infrastructure\PaginatedResult8;
 
 class OrderEndpointTest extends AbstractEndpointTest
 {
@@ -17,9 +18,13 @@ class OrderEndpointTest extends AbstractEndpointTest
 
     public function testFetchAll(): string
     {
-        /** @var PaginatedResult $orders */
+        /** @var PaginatedResult7 $orders */
         $orders = $this->endpoint->fetchAll(1);
-        $this->assertInstanceOf(PaginatedResult::class, $orders);
+        if (PHP_VERSION_ID < 80000) {
+            $this->assertInstanceOf(PaginatedResult7::class, $orders);
+        } else {
+            $this->assertInstanceOf(PaginatedResult8::class, $orders);
+        }
         return $orders->current()['id'];
     }
 

--- a/tests/Unit/Domain/Entity/EnvironmentTest.php
+++ b/tests/Unit/Domain/Entity/EnvironmentTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class EnvironmentTest extends TestCase
 {
-    public function environmentModesProvider(): array
+    public static function environmentModesProvider(): array
     {
         return [
             ['live', Environment::LIVE_API_URL],

--- a/tests/Unit/Domain/ValueObject/DataExportTest.php
+++ b/tests/Unit/Domain/ValueObject/DataExportTest.php
@@ -15,6 +15,9 @@ class DataExportTest extends TestCase
         $dataExport = new DataExport([]);
         $reflection = new \ReflectionClass($dataExport);
         $property = $reflection->getProperty('complete');
+        if (PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
         $property->setValue($dataExport, true);
 
         $this->assertTrue($dataExport->isComplete());
@@ -25,6 +28,9 @@ class DataExportTest extends TestCase
         $dataExport = new DataExport([]);
         $reflection = new \ReflectionClass($dataExport);
         $property = $reflection->getProperty('complete');
+        if (PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
         $property->setValue($dataExport, false);
 
         $this->assertFalse($dataExport->isComplete());
@@ -35,6 +41,9 @@ class DataExportTest extends TestCase
         $dataExport = new DataExport([]);
         $reflection = new \ReflectionClass($dataExport);
         $property = $reflection->getProperty('created');
+        if (PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
         $property->setValue($dataExport, 1633024800);
 
         $this->assertEquals(1633024800, $dataExport->getCreated());
@@ -45,6 +54,9 @@ class DataExportTest extends TestCase
         $dataExport = new DataExport([]);
         $reflection = new \ReflectionClass($dataExport);
         $property = $reflection->getProperty('csvUrl');
+        if (PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
         $property->setValue($dataExport, 'https://example.com/export.csv');
 
         $this->assertEquals('https://example.com/export.csv', $dataExport->getCsvUrl());
@@ -55,6 +67,9 @@ class DataExportTest extends TestCase
         $dataExport = new DataExport([]);
         $reflection = new \ReflectionClass($dataExport);
         $property = $reflection->getProperty('type');
+        if (PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
         $property->setValue($dataExport, 'payments');
 
         $this->assertEquals('payments', $dataExport->getType());
@@ -65,6 +80,9 @@ class DataExportTest extends TestCase
         $dataExport = new DataExport([]);
         $reflection = new \ReflectionClass($dataExport);
         $property = $reflection->getProperty('updated');
+        if (PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
         $property->setValue($dataExport, 1633025800);
 
         $this->assertEquals(1633025800, $dataExport->getUpdated());
@@ -75,6 +93,9 @@ class DataExportTest extends TestCase
         $dataExport = new DataExport([]);
         $reflection = new \ReflectionClass($dataExport);
         $property = $reflection->getProperty('end');
+        if (PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
         $property->setValue($dataExport, 1633024800);
 
         $this->assertEquals(1633024800, $dataExport->getEnd());
@@ -86,6 +107,9 @@ class DataExportTest extends TestCase
         $dataExport = new DataExport([]);
         $reflection = new \ReflectionClass($dataExport);
         $property = $reflection->getProperty('start');
+        if (PHP_VERSION_ID < 80100) {
+            $property->setAccessible(true);
+        }
         $property->setValue($dataExport, 1633024800);
 
         $this->assertEquals(1633024800, $dataExport->getStart());

--- a/tests/Unit/Domain/ValueObject/DataExportTest.php
+++ b/tests/Unit/Domain/ValueObject/DataExportTest.php
@@ -15,7 +15,6 @@ class DataExportTest extends TestCase
         $dataExport = new DataExport([]);
         $reflection = new \ReflectionClass($dataExport);
         $property = $reflection->getProperty('complete');
-        $property->setAccessible(true);
         $property->setValue($dataExport, true);
 
         $this->assertTrue($dataExport->isComplete());
@@ -26,7 +25,6 @@ class DataExportTest extends TestCase
         $dataExport = new DataExport([]);
         $reflection = new \ReflectionClass($dataExport);
         $property = $reflection->getProperty('complete');
-        $property->setAccessible(true);
         $property->setValue($dataExport, false);
 
         $this->assertFalse($dataExport->isComplete());
@@ -37,7 +35,6 @@ class DataExportTest extends TestCase
         $dataExport = new DataExport([]);
         $reflection = new \ReflectionClass($dataExport);
         $property = $reflection->getProperty('created');
-        $property->setAccessible(true);
         $property->setValue($dataExport, 1633024800);
 
         $this->assertEquals(1633024800, $dataExport->getCreated());
@@ -48,7 +45,6 @@ class DataExportTest extends TestCase
         $dataExport = new DataExport([]);
         $reflection = new \ReflectionClass($dataExport);
         $property = $reflection->getProperty('csvUrl');
-        $property->setAccessible(true);
         $property->setValue($dataExport, 'https://example.com/export.csv');
 
         $this->assertEquals('https://example.com/export.csv', $dataExport->getCsvUrl());
@@ -59,7 +55,6 @@ class DataExportTest extends TestCase
         $dataExport = new DataExport([]);
         $reflection = new \ReflectionClass($dataExport);
         $property = $reflection->getProperty('type');
-        $property->setAccessible(true);
         $property->setValue($dataExport, 'payments');
 
         $this->assertEquals('payments', $dataExport->getType());
@@ -70,7 +65,6 @@ class DataExportTest extends TestCase
         $dataExport = new DataExport([]);
         $reflection = new \ReflectionClass($dataExport);
         $property = $reflection->getProperty('updated');
-        $property->setAccessible(true);
         $property->setValue($dataExport, 1633025800);
 
         $this->assertEquals(1633025800, $dataExport->getUpdated());
@@ -81,7 +75,6 @@ class DataExportTest extends TestCase
         $dataExport = new DataExport([]);
         $reflection = new \ReflectionClass($dataExport);
         $property = $reflection->getProperty('end');
-        $property->setAccessible(true);
         $property->setValue($dataExport, 1633024800);
 
         $this->assertEquals(1633024800, $dataExport->getEnd());
@@ -93,7 +86,6 @@ class DataExportTest extends TestCase
         $dataExport = new DataExport([]);
         $reflection = new \ReflectionClass($dataExport);
         $property = $reflection->getProperty('start');
-        $property->setAccessible(true);
         $property->setValue($dataExport, 1633024800);
 
         $this->assertEquals(1633024800, $dataExport->getStart());

--- a/tests/Unit/Infrastructure/Endpoint/OrderEndpointTest.php
+++ b/tests/Unit/Infrastructure/Endpoint/OrderEndpointTest.php
@@ -273,17 +273,15 @@ class OrderEndpointTest extends AbstractEndpointSetUp
         $this->clientMock->shouldReceive('sendRequest')->times(5)->andReturn($this->fetchAllResponseMock);
 
         // Assertions
+        $classname = PaginatedResult8::class;
         if (PHP_VERSION_ID < 80000) {
-            $this->assertInstanceOf(PaginatedResult7::class, $this->orderServiceMock->fetchAll());
-            $this->assertInstanceOf(PaginatedResult7::class, $this->orderServiceMock->fetchAll(20, 'starting_after'));
-            $this->assertInstanceOf(PaginatedResult7::class, $this->orderServiceMock->fetchAll(20, null, ['status' => 'pending']));
-            $this->assertInstanceOf(PaginatedResult7::class, $this->orderServiceMock->fetchAll(1)->nextPage());
-        } else {
-            $this->assertInstanceOf(PaginatedResult8::class, $this->orderServiceMock->fetchAll());
-            $this->assertInstanceOf(PaginatedResult8::class, $this->orderServiceMock->fetchAll(20, 'starting_after'));
-            $this->assertInstanceOf(PaginatedResult8::class, $this->orderServiceMock->fetchAll(20, null, ['status' => 'pending']));
-            $this->assertInstanceOf(PaginatedResult8::class, $this->orderServiceMock->fetchAll(1)->nextPage());
+            $classname = PaginatedResult7::class;
         }
+        $this->assertInstanceOf($classname, $this->orderServiceMock->fetchAll());
+        $this->assertInstanceOf($classname, $this->orderServiceMock->fetchAll(20, 'starting_after'));
+        $this->assertInstanceOf($classname, $this->orderServiceMock->fetchAll(20, null, ['status' => 'pending']));
+        $this->assertInstanceOf($classname, $this->orderServiceMock->fetchAll(1)->nextPage());
+
     }
 
     /**

--- a/tests/Unit/Infrastructure/Endpoint/OrderEndpointTest.php
+++ b/tests/Unit/Infrastructure/Endpoint/OrderEndpointTest.php
@@ -8,6 +8,8 @@ use Alma\API\Infrastructure\Exception\ClientException;
 use Alma\API\Infrastructure\Exception\Endpoint\OrderEndpointException;
 use Alma\API\Infrastructure\Helper\ArrayHelper;
 use Alma\API\Infrastructure\PaginatedResult;
+use Alma\API\Infrastructure\PaginatedResult7;
+use Alma\API\Infrastructure\PaginatedResult8;
 use Alma\API\Infrastructure\Response;
 use Mockery;
 use Mockery\Mock;
@@ -271,10 +273,17 @@ class OrderEndpointTest extends AbstractEndpointSetUp
         $this->clientMock->shouldReceive('sendRequest')->times(5)->andReturn($this->fetchAllResponseMock);
 
         // Assertions
-        $this->assertInstanceOf(PaginatedResult::class, $this->orderServiceMock->fetchAll());
-        $this->assertInstanceOf(PaginatedResult::class, $this->orderServiceMock->fetchAll(20, 'starting_after'));
-        $this->assertInstanceOf(PaginatedResult::class, $this->orderServiceMock->fetchAll(20, null, ['status' => 'pending']));
-        $this->assertInstanceOf(PaginatedResult::class, $this->orderServiceMock->fetchAll(1)->nextPage());
+        if (PHP_VERSION_ID < 80000) {
+            $this->assertInstanceOf(PaginatedResult7::class, $this->orderServiceMock->fetchAll());
+            $this->assertInstanceOf(PaginatedResult7::class, $this->orderServiceMock->fetchAll(20, 'starting_after'));
+            $this->assertInstanceOf(PaginatedResult7::class, $this->orderServiceMock->fetchAll(20, null, ['status' => 'pending']));
+            $this->assertInstanceOf(PaginatedResult7::class, $this->orderServiceMock->fetchAll(1)->nextPage());
+        } else {
+            $this->assertInstanceOf(PaginatedResult8::class, $this->orderServiceMock->fetchAll());
+            $this->assertInstanceOf(PaginatedResult8::class, $this->orderServiceMock->fetchAll(20, 'starting_after'));
+            $this->assertInstanceOf(PaginatedResult8::class, $this->orderServiceMock->fetchAll(20, null, ['status' => 'pending']));
+            $this->assertInstanceOf(PaginatedResult8::class, $this->orderServiceMock->fetchAll(1)->nextPage());
+        }
     }
 
     /**

--- a/tests/Unit/Infrastructure/PaginatedResultTest.php
+++ b/tests/Unit/Infrastructure/PaginatedResultTest.php
@@ -2,13 +2,17 @@
 
 namespace Alma\API\Tests\Unit\Infrastructure;
 
-use Alma\API\Infrastructure\PaginatedResult;
+use Alma\API\Infrastructure\PaginatedResult7;
+use Alma\API\Infrastructure\PaginatedResult8;
+use Alma\API\Infrastructure\PaginatedResultCompatibilityTrait;
 use Alma\API\Infrastructure\Response;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 
 class PaginatedResultTest extends TestCase
 {
+    use PaginatedResultCompatibilityTrait;
+
     const FIRST_ITEMS_RESPONSE_JSON = '{
         "data": [
             {
@@ -52,12 +56,21 @@ class PaginatedResultTest extends TestCase
         $nextResponseMock->shouldReceive('getJson')->andReturn(json_decode(self::NEXT_ITEMS_RESPONSE_JSON, true));
 
         // PaginatedResult
-        $paginatedResult = new PaginatedResult(
-            $responseMock,
-            function () use ($nextResponseMock) {
-                return new PaginatedResult($nextResponseMock, null);
-            }
-        );
+        if (PHP_VERSION_ID < 80000) {
+            $paginatedResult = new PaginatedResult7(
+                $responseMock,
+                function () use ($nextResponseMock) {
+                    return new PaginatedResult7($nextResponseMock, null);
+                }
+            );
+        } else {
+            $paginatedResult = new PaginatedResult8(
+                $responseMock,
+                function () use ($nextResponseMock) {
+                    return new PaginatedResult8($nextResponseMock, null);
+                }
+            );
+        }
 
         // Assertions
         $this->assertEquals(["comment" => "comment 1","id" => "1"], $paginatedResult->current());


### PR DESCRIPTION
### Reason for change

PHP-Client use PHP features that are deprecated in PHP8. We need to adpat to be compatible with PHP8 and php 7.4

[Linear task](https://linear.app/almapay/issue/ECOM-3597/add-php8-compatibility)

### Code changes

Duplicate PaginatedResult to be compatible both with PHP7.x and PHP8.x
Set nullable parameters explicitely

### How to test

Launch unit test and compatibility yests.