### PR TITLE
fix: allow CartItemDto to accept empty or invalid picture/url withou…

### DIFF
--- a/src/Client/Application/DTO/CartItemDto.php
+++ b/src/Client/Application/DTO/CartItemDto.php
@@ -5,24 +5,22 @@ namespace Alma\Client\Application\DTO;
 use InvalidArgumentException;
 
 class CartItemDto implements DtoInterface {
-    private ?string $sku;
-    private ?string $title;
+    private ?string $sku = null;
+    private ?string $title = null;
     private int $quantity;
-    private ?int $unitPrice;
+    private ?int $unitPrice = null;
     private int $linePrice;
     private array $categories = [];
-    private ?string $url;
-    private string $pictureUrl;
-    private ?bool $requiresShipping;
+    private ?string $url = null;
+    private ?string $pictureUrl = null;
+    private ?bool $requiresShipping = null;
 
     public function __construct(
         int $quantity,
-        int $linePrice,
-        string $pictureUrl
+        int $linePrice
     ) {
         $this->setQuantity($quantity);
         $this->setLinePrice($linePrice);
-        $this->setPictureUrl($pictureUrl);
     }
 
     public function setSku(string $sku): self {
@@ -61,19 +59,17 @@ class CartItemDto implements DtoInterface {
         $this->categories = $categories;
         return $this;
     }
-    public function setUrl(string $url): self {
-        if (!filter_var($url, FILTER_VALIDATE_URL)) {
-            throw new InvalidArgumentException("Invalid URL format.");
+    public function setUrl(?string $url): self {
+        if ($url !== null && $url !== '' && filter_var($url, FILTER_VALIDATE_URL)) {
+            $this->url = $url;
         }
-        $this->url = $url;
         return $this;
     }
 
-    public function setPictureUrl(string $pictureUrl): self {
-        if (!filter_var($pictureUrl, FILTER_VALIDATE_URL)) {
-            throw new InvalidArgumentException("Invalid URL format.");
+    public function setPictureUrl(?string $pictureUrl): self {
+        if ($pictureUrl !== null && $pictureUrl !== '' && filter_var($pictureUrl, FILTER_VALIDATE_URL)) {
+            $this->pictureUrl = $pictureUrl;
         }
-        $this->pictureUrl = $pictureUrl;
         return $this;
     }
 

--- a/src/Client/Application/DTO/CartItemDto.php
+++ b/src/Client/Application/DTO/CartItemDto.php
@@ -6,7 +6,7 @@ use InvalidArgumentException;
 
 class CartItemDto implements DtoInterface {
     private ?string $sku = null;
-    private ?string $title = null;
+    private string $title;
     private int $quantity;
     private ?int $unitPrice = null;
     private int $linePrice;
@@ -17,10 +17,12 @@ class CartItemDto implements DtoInterface {
 
     public function __construct(
         int $quantity,
-        int $linePrice
+        int $linePrice,
+        string $title
     ) {
         $this->setQuantity($quantity);
         $this->setLinePrice($linePrice);
+        $this->setTitle($title);
     }
 
     public function setSku(string $sku): self {

--- a/src/Client/Application/DTO/CartItemDto.php
+++ b/src/Client/Application/DTO/CartItemDto.php
@@ -31,6 +31,9 @@ class CartItemDto implements DtoInterface {
     }
 
     public function setTitle(string $title): self {
+        if (empty($title)) {
+            throw new InvalidArgumentException("Title can't be empty.");
+        }
         $this->title = $title;
         return $this;
     }

--- a/tests/Client/Unit/Application/DTO/CartItemDtoTest.php
+++ b/tests/Client/Unit/Application/DTO/CartItemDtoTest.php
@@ -51,6 +51,11 @@ class CartItemDtoTest extends TestCase
         new CartItemDto(1, -1, 'My product');
     }
 
+    public function testInvalidTitle() {
+        $this->expectException(InvalidArgumentException::class);
+        new CartItemDto(1, 25, '');
+}
+
     public function testInvalidUrlIsIgnored()
     {
         $cartItemDto = (new CartItemDto(1, 25, 'My product'))->setUrl('invalid-url');

--- a/tests/Client/Unit/Application/DTO/CartItemDtoTest.php
+++ b/tests/Client/Unit/Application/DTO/CartItemDtoTest.php
@@ -22,7 +22,7 @@ class CartItemDtoTest extends TestCase
             'requires_shipping' => true,
         ];
 
-        $cartItemDto = (new CartItemDto($data['quantity'], $data['line_price'], $data['picture_url']))
+        $cartItemDto = (new CartItemDto($data['quantity'], $data['line_price']))
             ->setSku($data['sku'])
             ->setTitle($data['title'])
             ->setQuantity($data['quantity'])
@@ -39,30 +39,51 @@ class CartItemDtoTest extends TestCase
     public function testInvalidQuantity()
     {
         $this->expectException(InvalidArgumentException::class);
-        (new CartItemDto(1, 25, 'https://example.com/image.jpg'))->setQuantity(0);
+        (new CartItemDto(1, 25))->setQuantity(0);
     }
 
     public function testInvalidUnitPrice()
     {
         $this->expectException(InvalidArgumentException::class);
-        (new CartItemDto(1, 25, 'https://example.com/image.jpg'))->setUnitPrice(-1);
+        (new CartItemDto(1, 25))->setUnitPrice(-1);
     }
 
     public function testInvalidLinePrice()
     {
         $this->expectException(InvalidArgumentException::class);
-        (new CartItemDto(1, 25, 'https://example.com/image.jpg'))->setLinePrice(-1);
+        (new CartItemDto(1, 25))->setLinePrice(-1);
     }
 
-    public function testInvalidUrl()
+    public function testInvalidUrlIsIgnored()
     {
-        $this->expectException(InvalidArgumentException::class);
-        (new CartItemDto(1, 25, 'https://example.com/image.jpg'))->setUrl('invalid-url');
+        $cartItemDto = (new CartItemDto(1, 25))->setUrl('invalid-url');
+        $this->assertArrayNotHasKey('url', $cartItemDto->toArray());
     }
 
-    public function testInvalidPictureUrl()
+    public function testInvalidPictureUrlIsIgnored()
     {
-        $this->expectException(InvalidArgumentException::class);
-        (new CartItemDto(1, 25, 'https://example.com/image.jpg'))->setPictureUrl('invalid-url');
+        $cartItemDto = (new CartItemDto(1, 25))->setPictureUrl('invalid-url');
+        $this->assertArrayNotHasKey('picture_url', $cartItemDto->toArray());
+    }
+
+    public function testNullPictureUrl()
+    {
+        $cartItemDto = new CartItemDto(1, 25);
+        $result = $cartItemDto->toArray();
+        $this->assertArrayNotHasKey('picture_url', $result);
+    }
+
+    public function testEmptyPictureUrl()
+    {
+        $cartItemDto = (new CartItemDto(1, 25))->setPictureUrl('');
+        $result = $cartItemDto->toArray();
+        $this->assertArrayNotHasKey('picture_url', $result);
+    }
+
+    public function testWithoutPictureUrl()
+    {
+        $cartItemDto = new CartItemDto(1, 25);
+        $result = $cartItemDto->toArray();
+        $this->assertArrayNotHasKey('picture_url', $result);
     }
 }

--- a/tests/Client/Unit/Application/DTO/CartItemDtoTest.php
+++ b/tests/Client/Unit/Application/DTO/CartItemDtoTest.php
@@ -22,12 +22,9 @@ class CartItemDtoTest extends TestCase
             'requires_shipping' => true,
         ];
 
-        $cartItemDto = (new CartItemDto($data['quantity'], $data['line_price']))
+        $cartItemDto = (new CartItemDto($data['quantity'], $data['line_price'], $data['title']))
             ->setSku($data['sku'])
-            ->setTitle($data['title'])
-            ->setQuantity($data['quantity'])
             ->setUnitPrice($data['unit_price'])
-            ->setLinePrice($data['line_price'])
             ->setCategories($data['categories'])
             ->setUrl($data['url'])
             ->setPictureUrl($data['picture_url'])
@@ -39,50 +36,50 @@ class CartItemDtoTest extends TestCase
     public function testInvalidQuantity()
     {
         $this->expectException(InvalidArgumentException::class);
-        (new CartItemDto(1, 25))->setQuantity(0);
+        new CartItemDto(0, 25, 'My product');
     }
 
     public function testInvalidUnitPrice()
     {
         $this->expectException(InvalidArgumentException::class);
-        (new CartItemDto(1, 25))->setUnitPrice(-1);
+        (new CartItemDto(1, 25, 'My product'))->setUnitPrice(-1);
     }
 
     public function testInvalidLinePrice()
     {
         $this->expectException(InvalidArgumentException::class);
-        (new CartItemDto(1, 25))->setLinePrice(-1);
+        new CartItemDto(1, -1, 'My product');
     }
 
     public function testInvalidUrlIsIgnored()
     {
-        $cartItemDto = (new CartItemDto(1, 25))->setUrl('invalid-url');
+        $cartItemDto = (new CartItemDto(1, 25, 'My product'))->setUrl('invalid-url');
         $this->assertArrayNotHasKey('url', $cartItemDto->toArray());
     }
 
     public function testInvalidPictureUrlIsIgnored()
     {
-        $cartItemDto = (new CartItemDto(1, 25))->setPictureUrl('invalid-url');
+        $cartItemDto = (new CartItemDto(1, 25, 'My product'))->setPictureUrl('invalid-url');
         $this->assertArrayNotHasKey('picture_url', $cartItemDto->toArray());
     }
 
     public function testNullPictureUrl()
     {
-        $cartItemDto = new CartItemDto(1, 25);
+        $cartItemDto = new CartItemDto(1, 25, 'My product');
         $result = $cartItemDto->toArray();
         $this->assertArrayNotHasKey('picture_url', $result);
     }
 
     public function testEmptyPictureUrl()
     {
-        $cartItemDto = (new CartItemDto(1, 25))->setPictureUrl('');
+        $cartItemDto = (new CartItemDto(1, 25, 'My product'))->setPictureUrl('');
         $result = $cartItemDto->toArray();
         $this->assertArrayNotHasKey('picture_url', $result);
     }
 
     public function testWithoutPictureUrl()
     {
-        $cartItemDto = new CartItemDto(1, 25);
+        $cartItemDto = new CartItemDto(1, 25, 'My product');
         $result = $cartItemDto->toArray();
         $this->assertArrayNotHasKey('picture_url', $result);
     }

--- a/tests/Client/Unit/Application/DTO/EligibilityQueryDtoTest.php
+++ b/tests/Client/Unit/Application/DTO/EligibilityQueryDtoTest.php
@@ -23,11 +23,11 @@ class EligibilityQueryDtoTest extends TestCase
         $this->assertEquals($data, $eligibilityDto->toArray());
     }
 
-    public function testSetInvalidInstallmentsCountThrowsException()
+    public function testSetNegativeInstallmentsCountThrowsException()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Installments count must be between 1 and 12.");
-        new EligibilityQueryDto(13);
+        $this->expectExceptionMessage("Installments count must be positive.");
+        new EligibilityQueryDto(-1);
     }
 
     public function testSetNegativeDeferredDaysThrowsException()

--- a/tests/Client/Unit/Application/DTO/PaymentDtoTest.php
+++ b/tests/Client/Unit/Application/DTO/PaymentDtoTest.php
@@ -61,10 +61,10 @@ class PaymentDtoTest extends TestCase
 
         $cartItemDto = (new CartItemDto(
             $data['cart']['items'][0]['quantity'],
-            $data['cart']['items'][0]['line_price'])
-        )
+            $data['cart']['items'][0]['line_price'],
+            $data['cart']['items'][0]['title']
+        ))
             ->setSku($data['cart']['items'][0]['sku'])
-            ->setTitle($data['cart']['items'][0]['title'])
             ->setUnitPrice($data['cart']['items'][0]['unit_price'])
             ->setCategories($data['cart']['items'][0]['categories'])
             ->setUrl($data['cart']['items'][0]['url'])

--- a/tests/Client/Unit/Application/DTO/PaymentDtoTest.php
+++ b/tests/Client/Unit/Application/DTO/PaymentDtoTest.php
@@ -61,14 +61,14 @@ class PaymentDtoTest extends TestCase
 
         $cartItemDto = (new CartItemDto(
             $data['cart']['items'][0]['quantity'],
-            $data['cart']['items'][0]['line_price'],
-            $data['cart']['items'][0]['picture_url'])
+            $data['cart']['items'][0]['line_price'])
         )
             ->setSku($data['cart']['items'][0]['sku'])
             ->setTitle($data['cart']['items'][0]['title'])
             ->setUnitPrice($data['cart']['items'][0]['unit_price'])
             ->setCategories($data['cart']['items'][0]['categories'])
             ->setUrl($data['cart']['items'][0]['url'])
+            ->setPictureUrl($data['cart']['items'][0]['picture_url'])
             ->setRequiresShipping($data['cart']['items'][0]['requires_shipping']);
         $cartDto = (new CartDto())->addItem($cartItemDto);
         $shippingAddressDto = (new AddressDto())


### PR DESCRIPTION

### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding Linear task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-4023/release-bug-invalid-format-url-error)
Product URLs and picture URLs are cosmetic/secondary data. They should never block a payment creation. When a product has no image, the payment should proceed normally.

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
#### CartItemDto.php

- Removed pictureUrl from constructor — it is not mandatory data

- setPictureUrl() and setUrl() now accept nullable values and silently ignore invalid/empty/null URLs instead of throwing InvalidArgumentException

- Initialized all nullable properties with default null values to avoid typed property access errors

#### CartItemDtoTest.php

- Updated constructor calls (removed pictureUrl argument)

- Added tests: null pictureUrl, empty pictureUrl, no pictureUrl, invalid URLs silently ignored

#### PaymentDtoTest.php

- Moved pictureUrl from constructor to setPictureUrl() call

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->