### PR TITLE
feat: Fix PHP client to avoid API mode values to silently fallback to…

### DIFF
--- a/src/Client/Domain/ValueObject/Environment.php
+++ b/src/Client/Domain/ValueObject/Environment.php
@@ -27,9 +27,14 @@ final class Environment {
      * @param string $customApiUrl The custom API URL, required if mode is custom
      */
     public function __construct(string $mode, string $customApiUrl = '') {
-        // Check mode
-        if (!in_array($mode, [self::LIVE_MODE, self::TEST_MODE, self::CUSTOM_MODE])) {
-            $mode = self::LIVE_MODE;
+        if (!in_array($mode, [self::LIVE_MODE, self::TEST_MODE, self::CUSTOM_MODE], true)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Invalid environment mode "%s". Allowed values are: %s.',
+                    $mode,
+                    implode(', ', [self::LIVE_MODE, self::TEST_MODE, self::CUSTOM_MODE])
+                )
+            );
         }
         if ($mode === self::CUSTOM_MODE && empty($customApiUrl)) {
             throw new InvalidArgumentException('Custom API URL must be provided for custom mode.');

--- a/tests/Client/Unit/Application/ClientConfigurationTest.php
+++ b/tests/Client/Unit/Application/ClientConfigurationTest.php
@@ -4,6 +4,7 @@ namespace Alma\Client\Tests\Unit\Application;
 
 use Alma\Client\Application\ClientConfiguration;
 use Alma\Client\Domain\ValueObject\Environment;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 class ClientConfigurationTest extends TestCase
@@ -24,14 +25,14 @@ class ClientConfigurationTest extends TestCase
     }
 
     /**
-     * Ensure we can't create a ClientConfiguration with an invalid mode,
-     * and it defaults to LIVE_MODE
+     * Ensure that creating an Environment with an invalid mode throws an InvalidArgumentException.
      * @return void
      */
     public function testInvalidMode()
     {
-        $clientConfiguration = new ClientConfiguration('sk_test_xxxxxxxxxxxx', new Environment('INVALID_MODE'));
-        $this->assertEquals(new Environment(Environment::LIVE_MODE), $clientConfiguration->getEnvironment());
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid environment mode "INVALID_MODE". Allowed values are: live, test, custom.');
+        new Environment('INVALID_MODE');
     }
 
     /**

--- a/tests/Client/Unit/Domain/Entity/EnvironmentTest.php
+++ b/tests/Client/Unit/Domain/Entity/EnvironmentTest.php
@@ -28,11 +28,25 @@ class EnvironmentTest extends TestCase
         $this->assertEquals(Uri::fromString($expectedUrl), $environment->getBaseUri());
     }
 
-    public function testInvalidModeDefaultsToLive()
+    public static function invalidModesProvider(): array
     {
-        $environment = new Environment('invalid_mode');
-        $this->assertEquals(Environment::LIVE_MODE, $environment->getMode());
-        $this->assertEquals(Uri::fromString(Environment::LIVE_API_URL), $environment->getBaseUri());
+        return [
+            ['invalid_mode'],
+            ['Live'],
+            ['Test'],
+            ['LIVE'],
+        ];
+    }
+
+    /** @dataProvider invalidModesProvider */
+    public function testInvalidModeThrowsException(string $invalidMode)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Invalid environment mode "%s". Allowed values are: live, test, custom.',
+            $invalidMode
+        ));
+        new Environment($invalidMode);
     }
 
     public function testCustomModeWithoutUrlThrowsException()


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding Linear task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-4030/fix-php-client-to-avoid-api-mode-values-to-silently-fallback-to)

Especially in a case sensitive context where :
mode = 'live' => Prod
mode = 'Live' => Sandbox
=> We should not have silent fallback.
Either a fallback with a warning  : "Unknown value, falling back to sandbox"
or no fallback with an exception thrown.

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
1. Exception thrown instead of silent fallback — the behavior is explicit.

2. True as the third parameter of in_array — strict comparison (type + case), which strengthens the detection of cases like 'Live' or 'TEST'.
3. The `testInvalidMode` test: the old assertion checked for a silent fallback to LIVE_MODE. It now tests that `new Environment('INVALID_MODE')` correctly throws an `InvalidArgumentException` with the correct message.

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->