### PR TITLE
feat: curl_close deprecated on PHP 8

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -176,7 +176,9 @@ class Request
         }
 
         $response = new Response($this->curlHandle, $curl_res);
-        curl_close($this->curlHandle);
+        if (PHP_MAJOR_VERSION < 8) {
+            curl_close($this->curlHandle);
+        }
         return $response;
     }
 


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding Linear task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-XXX)
On save the configuration of Alma for Adobe Commerce 2.4.9 the error returned :
`Something went wrong while saving this configuration: Deprecated Functionality: Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0 in/app/adobe-commerce/app/code/Alma/API/Request.php on line 179`

On PHP 8.5 `curl_close` is deprecated it why we can't save the configuration on Adobe Commerce

This fix avoid this error and keep work for PHP 5.6

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
Remove curl_close before PHP 8 on exec request

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->